### PR TITLE
fix(docker): 実行ステージの起動コマンドを next 直接実行に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ ENV PORT=8080
 EXPOSE 8080
 
 # 実行コマンド
-CMD ["pnpm", "run", "start"]
+# 実行ステージには pnpm/corepack をセットアップしていないため、
+# パッケージマネージャを介さず next バイナリ（node_modules/.bin/next）を直接起動する。
+# ポートは next start が process.env.PORT（= 上の ENV PORT）を読むため指定不要。
+CMD ["node_modules/.bin/next", "start"]
 
 # =======================================================================

--- a/docs/09-architecture-specification/deploy-design.md
+++ b/docs/09-architecture-specification/deploy-design.md
@@ -10,6 +10,7 @@
 - インストール: `pnpm install --frozen-lockfile`
 - ビルド成果物: `.next/`, `public/`, `node_modules/`, `package.json`, `.env`
 - 環境変数: `NODE_ENV=production`, `PORT=8080`
+- 起動コマンド: 実行ステージには pnpm/corepack をセットアップしないため、`node_modules/.bin/next start` を直接実行する（パッケージマネージャに依存しない）。ポートは `next start` が `PORT` を読む。
 
 ### 5.2 CI/CDパイプライン
 ```


### PR DESCRIPTION
## 概要

Cloud Run のリビジョン起動失敗 `Error: Cannot find module '/app/pnpm'` を修正します。

### 原因
Dockerfile のマルチステージビルドで、`corepack enable`（pnpm 有効化）を **builder ステージでしか実行しておらず**、実行ステージ（最終イメージ）には pnpm が存在しない。にもかかわらず起動コマンドが `pnpm run start` だったため、PATH 上に `pnpm` 実体が無く、Node が `/app/pnpm` をスクリプトとして解釈して起動に失敗していた。

## 変更点
- `Dockerfile`: 起動コマンドを `pnpm run start` → `node_modules/.bin/next start` に変更（実行時に pnpm/corepack 不要）
- `docs/09-architecture-specification/deploy-design.md`: 起動コマンドの記載を追記

## 確認してほしいこと
- Docker イメージビルド → Cloud Run 再デプロイでコンテナが正常起動すること
- `next start` が `PORT`（=8080）を読んで listen すること（ローカルで `next start --help` が `env: PORT` を読む挙動を確認済み）

## ドキュメント影響（documentation.md 影響マップ）
- デプロイ構成の変更 → `docs/09-architecture-specification/deploy-design.md` を同一 PR で更新済み
- CLAUDE.md は構成技術の変更がないため更新不要

## 補足（本 PR では未対応）
- `.env` をイメージにコピーしている構成（39行目）はシークレット焼き込みのリスクあり。Secret Manager 注入への移行は別途検討。
- builder の `pnpm@latest` と package.json の `pnpm@10.33.0` の不一致（動作はするが将来揃える余地あり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)