### PR TITLE
chore(lint): ESLint に JSDoc(TSDoc) lint を導入し既存 JSDoc を補強

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -54,6 +54,12 @@ export async function resolveDisplayName(
 }
 ```
 
-## Lint による強制（推奨）
+## Lint による強制
 
-`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。
+`eslint-plugin-jsdoc` を `front/eslint.config.mjs` に導入済み（`src/**/*.{ts,tsx}` 対象）。機械的に判定できる部分を `pnpm lint`（`front/` で実行）で強制する。※本プロジェクトの CI に lint ステップはないため、ローカルで実行する。
+
+- `settings.jsdoc.mode: "typescript"` + `jsdoc/no-types`: 型の再掲を禁止（型は TS シグネチャが唯一の真実）。
+- `jsdoc/require-param` / `require-param-description` / `check-param-names`: `@param` の名前ズレ・説明漏れ・過不足を検出。**分割代入 props は展開しない**（`checkDestructured: false`。props は型 `XxxProps` 側で説明する）。
+- `jsdoc/require-returns` / `require-returns-description`: 返り値のある関数に `@returns` を要求。ただし JSX を返す `.tsx`（コンポーネント）は除外。
+- `jsdoc/check-alignment` / `jsdoc/no-multi-asterisks`: 体裁を `warn`。
+- `require-jsdoc` は未採用（JSDoc ブロックの**有無**はレビューで確認。ルールは書かれた JSDoc の**質**のみを強制する）。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # フォーマット・lint は install 直後に実行し、失敗時は後続の重いテストに進まない（fail fast）。
+      - name: Format check (Prettier)
+        run: pnpm run format:check
+
+      - name: Lint (ESLint)
+        run: pnpm run lint
+
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps chromium
 

--- a/docs/04-non-functional-specification.md
+++ b/docs/04-non-functional-specification.md
@@ -45,7 +45,7 @@
 | コード品質 | ESLint + Prettier |
 | パッケージマネージャー | pnpm（高速インストール・ディスク効率・厳格な依存解決） |
 | テスト | Jest（ユニットテスト）、Playwright（E2Eテスト） |
-| CI/CD | GitHub Actions（テスト→デプロイ）※CIにlint・buildステップはない |
+| CI/CD | GitHub Actions（format/lint→テスト→デプロイ）※build は Docker ビルド内で実行 |
 | コンテナ化 | Dockerマルチステージビルド |
 
 ## 5. デプロイ

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -108,10 +108,10 @@ GitHub Actionsワークフロー:
 
 ### テストパイプライン（test.yml）
 ```
-install → unit test (Jest) → e2e test (Playwright) → (deploy)
+install → format:check → lint → unit test (Jest) → e2e test (Playwright) → (deploy)
 ```
 
-**注意**: CIワークフローに `npm run lint` や `npm run build` のステップは含まれていない。lint・buildはローカル開発時に手動で実行する。
+**注意**: `format:check`（Prettier）・`lint`（ESLint）を install 直後に実行し、失敗時は後続の重いテストへ進まない（fail fast）。`build` ステップは CI に無く、Docker ビルド内で実行される。
 
 ## 6. テスト環境
 

--- a/docs/09-architecture-specification/deploy-design.md
+++ b/docs/09-architecture-specification/deploy-design.md
@@ -29,6 +29,8 @@
 [GitHub Actions - test.yml]
     ├── pnpm/action-setup でpnpmセットアップ
     ├── pnpm install --frozen-lockfile
+    ├── format:check (pnpm run format:check)
+    ├── lint (pnpm run lint)
     ├── pnpm exec playwright install --with-deps chromium
     ├── unit test (pnpm run test)
     └── e2e test (pnpm run test:e2e)
@@ -40,7 +42,7 @@
     └── Cleanup old images
 ```
 
-**注意**: CIにlint・buildステップは含まれていない。ビルドはDockerビルド内で実行される。
+**注意**: CI に `format:check`・`lint` を追加済み（install 直後、fail fast）。`build` ステップは CI に無く、Docker ビルド内で実行される。
 
 ## 6. デザインシステム
 

--- a/docs/09-architecture-specification/tech-stack.md
+++ b/docs/09-architecture-specification/tech-stack.md
@@ -70,6 +70,7 @@
 |------|----------|------|
 | pnpm | 10.33.0 | パッケージマネージャー |
 | ESLint | ^9.39.2 | 静的解析 |
+| eslint-plugin-jsdoc | ^63.0.12 | JSDoc(TSDoc) 規約の lint 強制（`front/eslint.config.mjs`） |
 | Prettier | ^3.4.2 | コードフォーマット |
 | Jest | ^29.7.0 | ユニットテスト |
 | Playwright | ^1.50.1 | E2Eテスト |

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -32,6 +32,8 @@
 | T-20 | npmからpnpmへのパッケージマネージャー移行 | 完了 |
 | T-21 | モノレポ化（アプリ本体を `front/` に集約。一体型は維持） | 完了 |
 | T-22 | メール送信の HTML インジェクション修正（入力の HTML エスケープ + text 併送 + Mail API ユニットテスト追加） | 完了 |
+| T-23 | ESLint に JSDoc(TSDoc) lint を導入（eslint-plugin-jsdoc。`youtube-my-collection` を参考） | 完了 |
+| T-24 | JSDoc 未記載の公開シンボルを補強（hook / Provider / shadcn UI / cn / route・metadata 等） | 完了 |
 
 ## 2. 未対応・検討中タスク
 

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -34,6 +34,7 @@
 | T-22 | メール送信の HTML インジェクション修正（入力の HTML エスケープ + text 併送 + Mail API ユニットテスト追加） | 完了 |
 | T-23 | ESLint に JSDoc(TSDoc) lint を導入（eslint-plugin-jsdoc。`youtube-my-collection` を参考） | 完了 |
 | T-24 | JSDoc 未記載の公開シンボルを補強（hook / Provider / shadcn UI / cn / route・metadata 等） | 完了 |
+| T-25 | CI（test.yml）に format:check・lint ステップを追加（install 直後・fail fast） | 完了 |
 
 ## 2. 未対応・検討中タスク
 

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -1,5 +1,41 @@
 import nextConfig from "eslint-config-next";
+import jsdoc from "eslint-plugin-jsdoc";
 
 export default [
   ...nextConfig,
+  // JSDoc（TSDoc スタイル）規約の、機械的に判定できる部分を強制する。
+  // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { jsdoc },
+    // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
+    settings: { jsdoc: { mode: "typescript" } },
+    rules: {
+      // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
+      "jsdoc/no-types": "error",
+      // JSDoc ブロックを持つ関数は全引数を @param で説明する。
+      // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
+      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
+      "jsdoc/require-param-description": "error",
+      // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
+      // 分割代入 props は require-param と同様に展開しない（props.x 単位の @param を要求しない）。
+      "jsdoc/check-param-names": ["error", { checkDestructured: false }],
+      // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      // 書いた JSDoc の体裁を整える。
+      "jsdoc/check-alignment": "warn",
+      "jsdoc/no-multi-asterisks": "warn",
+      // require-jsdoc は // 行コメントを誤検知するため未採用。ブロックの有無・質はレビューで確認する。
+    },
+  },
+  {
+    // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
+    // .ts のフック / lib / API では @returns 必須のまま。
+    files: ["src/**/*.tsx"],
+    rules: {
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
+    },
+  },
 ];

--- a/front/package.json
+++ b/front/package.json
@@ -54,6 +54,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-jsdoc": "^63.0.12",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-html-reporters": "^3.1.7",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^63.0.12
+        version: 63.0.12(eslint@9.39.2(jiti@1.21.7))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.16)
@@ -319,6 +322,14 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@es-joy/jsdoccomment@0.88.0':
+    resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -815,6 +826,10 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -871,6 +886,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -967,6 +985,10 @@ packages:
     resolution: {integrity: sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.54.0':
     resolution: {integrity: sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1017,6 +1039,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1058,6 +1085,10 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -1302,6 +1333,10 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1638,6 +1673,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-jsdoc@63.0.12:
+    resolution: {integrity: sha512-99VfBHyoLlF9n5w9wh+jLWDBzCgYd3tfw3M/aynAd+H2ylGHWLbde/GPTuo/5az3jMAN0fH7QzCYvEOY6u+Ypg==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -1668,6 +1709,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1682,6 +1727,10 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1689,6 +1738,10 @@ packages:
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -1981,6 +2034,9 @@ packages:
 
   html-entities@2.5.2:
     resolution: {integrity: sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2392,6 +2448,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
+
   jsdom@20.0.3:
     resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
     engines: {node: '>=14'}
@@ -2688,6 +2748,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
@@ -2766,9 +2829,15 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
@@ -3002,6 +3071,10 @@ packages:
     resolution: {integrity: sha512-nkcRpIOgPb3sFPA/GyOTr6Vmlrkhwsu+XlC20kKbbebOfw0WbAjbBbJ1m4AcjKOkPf57O4DH9Bnbxi9i18JYng==}
     engines: {node: '>=18'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -3082,6 +3155,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3146,6 +3224,15 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -3314,6 +3401,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
@@ -3780,6 +3871,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@es-joy/jsdoccomment@0.88.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.63.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
     dependencies:
@@ -4288,6 +4389,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -4359,6 +4462,8 @@ snapshots:
   '@types/caseless@0.12.5': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -4481,6 +4586,8 @@ snapshots:
 
   '@typescript-eslint/types@8.54.0': {}
 
+  '@typescript-eslint/types@8.63.0': {}
+
   '@typescript-eslint/typescript-estree@8.54.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.54.0(typescript@5.7.3)
@@ -4534,11 +4641,17 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -4577,6 +4690,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  are-docs-informative@0.0.2: {}
 
   arg@5.0.2: {}
 
@@ -4864,6 +4979,8 @@ snapshots:
   commander@10.0.1: {}
 
   commander@4.1.1: {}
+
+  comment-parser@1.4.7: {}
 
   concat-map@0.0.1: {}
 
@@ -5280,6 +5397,26 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsdoc@63.0.12(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.88.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.2(jiti@1.21.7)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       aria-query: 5.3.2
@@ -5341,6 +5478,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.2(jiti@1.21.7):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
@@ -5388,9 +5527,19 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
   esprima@4.0.1: {}
 
   esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -5718,6 +5867,8 @@ snapshots:
       whatwg-encoding: 2.0.0
 
   html-entities@2.5.2: {}
+
+  html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -6346,6 +6497,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@7.2.0: {}
+
   jsdom@20.0.3:
     dependencies:
       abab: 2.0.6
@@ -6619,6 +6772,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-deep-merge@2.0.1: {}
+
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
@@ -6713,12 +6868,18 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.28.6
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-statements@1.0.11: {}
 
   parse5@7.2.1:
     dependencies:
@@ -6937,6 +7098,8 @@ snapshots:
       - react
       - react-dom
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -7016,6 +7179,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -7121,6 +7286,15 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
 
@@ -7335,6 +7509,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   tough-cookie@4.1.4:
     dependencies:

--- a/front/src/app/api/[[...route]]/route.ts
+++ b/front/src/app/api/[[...route]]/route.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors';
 // router
 import gcsRouter from '@/app/api/gcs/gcs';
 import mailRouter from '@/app/api/mail/mail';
+/** Route Handler のランタイム。GCS SDK 等 Node 依存の API を使うため nodejs を指定する。 */
 export const runtime = 'nodejs';
 
 // Honoのインスタンスを作成
@@ -37,5 +38,7 @@ app.get('/hello', (c) => {
 app.route('/gcs', gcsRouter);
 app.route('/mail', mailRouter);
 
+/** Hono アプリを Next.js Route Handler として公開する（GET）。 */
 export const GET = handle(app);
+/** Hono アプリを Next.js Route Handler として公開する（POST）。 */
 export const POST = handle(app);

--- a/front/src/app/api/gcs/gcs.ts
+++ b/front/src/app/api/gcs/gcs.ts
@@ -12,7 +12,6 @@ const gcsRouter = new Hono();
  * @param fileName GCSのJSONファイルのパス
  * @returns JSONファイルの内容
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function fetchJsonFromGCS(bucketName: string, fileName: string): Promise<any> {
     try {
         const bucket = storage.bucket(bucketName);

--- a/front/src/app/components/modal/ConfirmModal.tsx
+++ b/front/src/app/components/modal/ConfirmModal.tsx
@@ -1,15 +1,14 @@
 interface ConfirmModalProps {
+    /** モーダルの開閉状態 */
     isOpen: boolean;
+    /** モーダルを閉じる処理 */
     onClose: () => void;
+    /** モーダルでの「送信する」ボタン押下時の処理 */
     onConfirm: () => void;
 }
 
 /**
- * 確認モーダル
- * @param isOpen モーダルの開閉状態
- * @param onClose モーダルの閉じる処理
- * @param onConfirm モーダルでの「送信する」ボタン押下時の処理
- * @returns 確認モーダル
+ * 確認モーダル。props の詳細は {@link ConfirmModalProps} を参照。
  */
 const ConfirmModal = ({ isOpen, onClose, onConfirm }: ConfirmModalProps) => {
     if (!isOpen) return null;

--- a/front/src/app/contexts/CommonContext.tsx
+++ b/front/src/app/contexts/CommonContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useState, ReactNode, useEffect } from
 // types
 import type { CommonDataType } from '@/app/types/common-data-types';
 
-// type
+/** 共通データ Context の状態。`isLoading` は取得中フラグ、`commonData` は取得結果（未取得時は null）。 */
 type CommonDataState = {
     isLoading: boolean;
     commonData: CommonDataType | null;
@@ -13,7 +13,12 @@ type CommonDataState = {
 // Context
 const CommonDataContext = createContext<CommonDataState | null>(null);
 
-// hooks
+/**
+ * 共通データ Context を取得するフック。
+ *
+ * @returns 共通データの状態（`isLoading` / `commonData`）
+ * @throws {Error} `CommonDataProvider` の外側で呼び出された場合
+ */
 export const useCommonData = () => {
     const context = useContext(CommonDataContext);
     if (!context) {
@@ -24,10 +29,14 @@ export const useCommonData = () => {
 
 // Props
 interface CommonDataProviderProps {
+    /** Provider 配下に共通データを供給する子要素 */
     children: ReactNode;
 }
 
-// Provider
+/**
+ * 共通データ（ポートフォリオ / ブログ / SNS リンク）を GCS から取得して配下に供給する Provider。
+ * マウント時に `/api/gcs/common` を fetch し、`CommonDataContext` 経由で提供する。
+ */
 export const CommonDataProvider: React.FC<CommonDataProviderProps> = ({ children }) => {
     // state
     const [commonData, setCommonData] = useState<CommonDataType | null>(null);

--- a/front/src/app/hooks/useModal.ts
+++ b/front/src/app/hooks/useModal.ts
@@ -17,6 +17,7 @@ export const useModal = () => {
 
     /**
      * モーダルでの「送信する」ボタン押下時の処理
+     * @param handleSubmit - モーダルを閉じた後に実行する送信処理
      */
     const handleExecute = (handleSubmit: () => void) => {
         setIsModalOpen(false);

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { CommonDataProvider } from './contexts/CommonContext';
 // styles
 import './globals.css';
 
+/** ページの既定メタデータ（`<title>` / `<meta name="description">`）。 */
 export const metadata: Metadata = {
     title: 'My Developers Hub',
     description: 'My Developers Hub',

--- a/front/src/app/personaldev/page.tsx
+++ b/front/src/app/personaldev/page.tsx
@@ -34,7 +34,6 @@ const PersonalHistoryDevPage = () => {
 
                     if (data.personaldev && Array.isArray(data.personaldev)) {
                         setPersonalDevDataList(
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             data.personaldev.map((item: any) => ({
                                 title: item.title,
                                 description: item.description,

--- a/front/src/app/sampledev/page.tsx
+++ b/front/src/app/sampledev/page.tsx
@@ -35,7 +35,6 @@ const SampleHistoryDevPage = () => {
 
                     if (data.sampledev && Array.isArray(data.sampledev)) {
                         setSampleDevDataList(
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             data.sampledev.map((item: any) => ({
                                 title: item.title,
                                 description: item.description,

--- a/front/src/components/ui/input.tsx
+++ b/front/src/components/ui/input.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/** テキスト入力フィールド（shadcn/ui）。ネイティブ `input` の props をそのまま受け取り、ref を転送する。 */
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
     ({ className, type, ...props }, ref) => {
         return (

--- a/front/src/components/ui/label.tsx
+++ b/front/src/components/ui/label.tsx
@@ -10,6 +10,7 @@ const labelVariants = cva(
     'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 );
 
+/** フォームラベル（shadcn/ui、Radix Label ベース）。関連付けは `htmlFor` で行う。 */
 const Label = React.forwardRef<
     React.ElementRef<typeof LabelPrimitive.Root>,
     React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>

--- a/front/src/components/ui/textarea.tsx
+++ b/front/src/components/ui/textarea.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/** 複数行テキスト入力（shadcn/ui）。ネイティブ `textarea` の props をそのまま受け取り、ref を転送する。 */
 const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
     ({ className, ...props }, ref) => {
         return (

--- a/front/src/lib/utils.ts
+++ b/front/src/lib/utils.ts
@@ -1,6 +1,13 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * className を結合するユーティリティ。clsx で条件付きクラスを合成し、
+ * tailwind-merge で Tailwind の競合クラス（例: `px-2` と `px-4`）を後勝ちで解決する。
+ *
+ * @param inputs - clsx が受け取れる className 値（文字列 / 配列 / オブジェクト等）
+ * @returns マージ済みの className 文字列
+ */
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## 概要

`youtube-my-collection`（参考・read-only）を参考に **`eslint-plugin-jsdoc`** を導入し、JSDoc(TSDoc) 規約の機械判定可能部分を lint で強制できるようにしました。未記載の公開シンボルに JSDoc を補強し、さらに **CI（test.yml）に format:check・lint ステップを追加**しています。

## 変更点

### 1. JSDoc lint 導入（T-23）
- `eslint-plugin-jsdoc@^63.0.12` を追加、`front/eslint.config.mjs` に jsdoc ブロックを設定
  - 対象 `src/**/*.{ts,tsx}`、`mode: "typescript"` + `jsdoc/no-types`（型の再掲禁止）
  - `require-param` 系 / `check-param-names`（**分割代入 props は展開しない** = `checkDestructured: false`）
  - `require-returns` 系（`.ts` のみ。JSX を返す `.tsx` は off）、体裁系は `warn`、`require-jsdoc` は未採用
- 既存 JSDoc の不備修正: `useModal`・`ConfirmModal`・`gcs.ts`・`personaldev`/`sampledev`

### 2. JSDoc 補強（T-24）
- `CommonContext`（`useCommonData` / `CommonDataProvider` / 型）、`lib/utils`（`cn`）、`components/ui/{input,label,textarea}`、`route.ts`（`runtime`/`GET`/`POST`）、`layout`（`metadata`）

### 3. CI に format:check・lint 追加（T-25）
- `.github/workflows/test.yml`: `install` 直後に **Format check（Prettier）→ Lint（ESLint）** を実行（fail fast。失敗時は Playwright install / e2e に進まない）
- `test.yml` は PR テスト（`pull-request-test.yml`）とデプロイ（`deploy-to-googlecloud.yml`）双方から `uses:` されるため、両経路で lint/format が走る
- ※ `build` は従来どおり CI に無く Docker ビルド内で実行

### 4. ドキュメント
- `.claude/rules/jsdoc.md`、`docs/09 tech-stack`・`deploy-design`、`docs/08`・`docs/04`（CI 記述）、`docs/11-tasks`（T-23〜T-25）

## レビュー観点
- next ベースは既存維持（`core-web-vitals`/`typescript` 分割・`@typescript-eslint` 追加ルール・`eslint-config-prettier/flat` は見送り）
- `check-param-names` に `checkDestructured:false` を追加（reference 未指定。既存 JSDoc の方針を貫徹）
- 補強は公開／エクスポート済みシンボルに限定
- reference の CI には `typecheck`（tsc）ステップもあるが、本 PR は依頼どおり lint/format のみ追加（typecheck 追加は容易・別途相談可）

## 検証（すべて green）
- ✅ `pnpm lint` — 0 problems ／ `pnpm format:check` — clean（＝CI が実行する内容）
- ✅ `tsc --noEmit` ／ `pnpm test` 11/11 ／ `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)