### PR TITLE
test(api): API ユニットテストに異常系（500 パス）を補強

### DIFF
--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -46,32 +46,31 @@ pnpm run format          # Prettier自動修正
 
 ### 3.1 GCS APIテスト (`__tests__/api/gcs.test.ts`)
 
-GCSの`@google-cloud/storage`をモックし、Hono Routerのレスポンスを検証する。
+GCSの`@google-cloud/storage`をモックし、Hono Routerのレスポンスを検証する。`file().download()` はテストから制御できる共有モックにし、異常系（500）も再現する。
 
-| テストケース | 期待結果 |
-|------------|---------|
-| `GET /common` - 正常系 | 200 + モックデータ |
-| `GET /common` - 環境変数未設定 | 400 + エラーメッセージ |
-| `GET /personaldev` - 正常系 | 200 + モックデータ |
-| `GET /personaldev` - 環境変数未設定 | 400 + エラーメッセージ |
-| `GET /sampledev` - 正常系 | 200 + モックデータ |
-| `GET /sampledev` - 環境変数未設定 | 400 + エラーメッセージ |
+| 分類 | テストケース | 期待結果 |
+|------|------------|---------|
+| 正常系 | `GET /common` `/personaldev` `/sampledev` | 200 + モックデータ |
+| 準正常系 | 各エンドポイント - 環境変数未設定 | 400 + `Bucket name or file name is not set` |
+| 異常系 | `GET /common` - download 例外 / 不正 JSON | 500 + `Failed to fetch data from GCS` |
+| 異常系 | `GET /personaldev` `/sampledev` - download 例外 | 500 + `Failed to fetch data from GCS` |
 
-合計: 6テストケース
+合計: 10テストケース（正常 3 / 準正常 3 / 異常 4）
 
 ### 3.2 メール送信APIテスト (`__tests__/api/mail.test.ts`)
 
-`resend`（メール送信）と `nanoid` をモックし、Hono Router のレスポンス・CSRF 検証・入力バリデーション・HTML エスケープを検証する。
+`resend`（メール送信）と `nanoid` をモックし、Hono Router のレスポンス・CSRF 検証・入力バリデーション・HTML エスケープ・失敗時の安全な失敗を検証する。
 
-| テストケース | 期待結果 |
-|------------|---------|
-| `POST /send` - 正常系 | 200 + `success: true`（Resend 呼び出し 1 回） |
-| `POST /send` - HTMLエスケープ（準正常系） | 入力の HTML をエスケープして送信（`<script>` 等が生のまま含まれない） |
-| `POST /send` - CSRFトークンなし（異常系） | 403 + `Invalid CSRF token` |
-| `POST /send` - トークン不一致（異常系） | 403 |
-| `POST /send` - 必須フィールド欠落（異常系） | 400 + `Missing required fields` |
+| 分類 | テストケース | 期待結果 |
+|------|------------|---------|
+| 正常系 | `POST /send` - 正常入力 | 200 + `success: true`（Resend 呼び出し 1 回） |
+| 準正常系 | HTML を含む入力 | エスケープして送信（`<script>` 等が生のまま含まれない） |
+| 準正常系 | CSRFトークンなし / 不一致 | 403 + `Invalid CSRF token` |
+| 準正常系 | 必須フィールド欠落 | 400 + `Missing required fields` |
+| 異常系 | Resend 例外 | 500 + `Failed to send email` |
+| 異常系 | 不正 JSON ボディ | 500 + `Failed to send email` |
 
-合計: 5テストケース
+合計: 7テストケース（正常 1 / 準正常 4 / 異常 2）
 
 ### 3.3 モックデータ
 

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -35,6 +35,7 @@
 | T-23 | ESLint に JSDoc(TSDoc) lint を導入（eslint-plugin-jsdoc。`youtube-my-collection` を参考） | 完了 |
 | T-24 | JSDoc 未記載の公開シンボルを補強（hook / Provider / shadcn UI / cn / route・metadata 等） | 完了 |
 | T-25 | CI（test.yml）に format:check・lint ステップを追加（install 直後・fail fast） | 完了 |
+| T-26 | API ユニットテストに異常系（500 パス）を補強（GCS download 例外・不正 JSON / Resend 例外・不正ボディ） | 完了 |
 
 ## 2. 未対応・検討中タスク
 

--- a/front/__tests__/api/gcs.test.ts
+++ b/front/__tests__/api/gcs.test.ts
@@ -1,107 +1,115 @@
 import gcsRouter from '@/app/api/gcs/gcs';
-import { Storage } from '@google-cloud/storage';
 
 const mockCommonData = require('../../e2e/tests/mock/common.json');
 const mockPersonalDevData = require('../../e2e/tests/mock/personaldev.json');
 const mockSampleDevData = require('../../e2e/tests/mock/sampledev.json');
 
-jest.mock('@google-cloud/storage', () => {
-    return {
-        Storage: jest.fn().mockImplementation(() => ({
-            bucket: jest.fn().mockReturnThis(),
-            file: jest.fn().mockImplementation(function (fileName: string) {
-                let data;
-                if (fileName.includes('common')) {
-                    data = mockCommonData;
-                } else if (fileName.includes('personaldev')) {
-                    data = mockPersonalDevData;
-                } else if (fileName.includes('sampledev')) {
-                    data = mockSampleDevData;
-                } else {
-                    data = {};
-                }
-                return {
-                    download: jest.fn().mockResolvedValue([Buffer.from(JSON.stringify(data))]),
-                };
-            }),
-        })),
-    };
+// GCS の file().download() をテストから制御できる共有モック。
+// 既定は fileName に応じたモックデータを返す。異常系では *Once で失敗を差し込む。
+const mockDownload = jest.fn(async (fileName: string) => {
+    let data;
+    if (fileName.includes('common')) {
+        data = mockCommonData;
+    } else if (fileName.includes('personaldev')) {
+        data = mockPersonalDevData;
+    } else if (fileName.includes('sampledev')) {
+        data = mockSampleDevData;
+    } else {
+        data = {};
+    }
+    return [Buffer.from(JSON.stringify(data))];
 });
 
-describe('GCS Router', () => {
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
+jest.mock('@google-cloud/storage', () => ({
+    Storage: jest.fn().mockImplementation(() => ({
+        bucket: jest.fn().mockReturnThis(),
+        file: jest.fn((fileName: string) => ({ download: () => mockDownload(fileName) })),
+    })),
+}));
 
-    test('GET /api/gcs/common - Normal', async () => {
+describe('GCS Router', () => {
+    // 既定はすべての環境変数が設定済み（正常系・異常系はこの状態を前提にする）
+    beforeEach(() => {
         process.env.GCS_PRIVATE_BUCKET_NAME = 'mock-bucket';
         process.env.GCS_COMMON_DATA_PATH = 'common/mock-data.json';
-
-        const req = new Request('http://localhost/common', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
-        expect(response.status).toBe(200);
-        const data = await response.json();
-        expect(data).toEqual(mockCommonData);
+        process.env.GCS_PERSONAL_DATA_PATH = 'personaldev/mock-data.json';
+        process.env.GCS_SAMPLE_DATA_PATH = 'sampledev/mock-data.json';
+        // 異常系で意図的に発生する console.error はテスト出力から抑制する
+        jest.spyOn(console, 'error').mockImplementation(() => {});
     });
 
-    test('GET /api/gcs/common - Abnormal (Environment variable not set)', async () => {
-        delete process.env.GCS_PRIVATE_BUCKET_NAME;
-        delete process.env.GCS_COMMON_DATA_PATH;
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
 
-        const req = new Request('http://localhost/common', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
-        expect(response.status).toBe(400);
-        const data = await response.json();
-        expect(data).toEqual({ error: 'Bucket name or file name is not set' });
+    // ---- 正常系（Normal）----
+    test('GET /api/gcs/common - Normal', async () => {
+        const response = await gcsRouter.fetch(new Request('http://localhost/common'));
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(mockCommonData);
     });
 
     test('GET /api/gcs/personaldev - Normal', async () => {
-        process.env.GCS_PRIVATE_BUCKET_NAME = 'mock-bucket';
-        process.env.GCS_PERSONAL_DATA_PATH = 'personaldev/mock-data.json';
-
-        const req = new Request('http://localhost/personaldev', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
+        const response = await gcsRouter.fetch(new Request('http://localhost/personaldev'));
         expect(response.status).toBe(200);
-        const data = await response.json();
-        expect(data).toEqual(mockPersonalDevData);
-    });
-
-    test('GET /api/gcs/personaldev - Abnormal (Environment variable not set)', async () => {
-        delete process.env.GCS_PRIVATE_BUCKET_NAME;
-        delete process.env.GCS_PERSONAL_DATA_PATH;
-
-        const req = new Request('http://localhost/personaldev', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
-        expect(response.status).toBe(400);
-        const data = await response.json();
-        expect(data).toEqual({ error: 'Bucket name or file name is not set' });
+        expect(await response.json()).toEqual(mockPersonalDevData);
     });
 
     test('GET /api/gcs/sampledev - Normal', async () => {
-        process.env.GCS_PRIVATE_BUCKET_NAME = 'mock-bucket';
-        process.env.GCS_SAMPLE_DATA_PATH = 'sampledev/mock-data.json';
-
-        const req = new Request('http://localhost/sampledev', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
+        const response = await gcsRouter.fetch(new Request('http://localhost/sampledev'));
         expect(response.status).toBe(200);
-        const data = await response.json();
-        expect(data).toEqual(mockSampleDevData);
+        expect(await response.json()).toEqual(mockSampleDevData);
     });
 
-    test('GET /api/gcs/sampledev - Abnormal (Environment variable not set)', async () => {
+    // ---- 準正常系（Semi-Normal）: 環境変数未設定 → 400 ----
+    test('GET /api/gcs/common - Semi-Normal (環境変数未設定 → 400)', async () => {
         delete process.env.GCS_PRIVATE_BUCKET_NAME;
-        delete process.env.GCS_SAMPLE_DATA_PATH;
-
-        const req = new Request('http://localhost/sampledev', { method: 'GET' });
-        const response = await gcsRouter.fetch(req);
-
+        const response = await gcsRouter.fetch(new Request('http://localhost/common'));
         expect(response.status).toBe(400);
-        const data = await response.json();
-        expect(data).toEqual({ error: 'Bucket name or file name is not set' });
+        expect(await response.json()).toEqual({ error: 'Bucket name or file name is not set' });
+    });
+
+    test('GET /api/gcs/personaldev - Semi-Normal (環境変数未設定 → 400)', async () => {
+        delete process.env.GCS_PERSONAL_DATA_PATH;
+        const response = await gcsRouter.fetch(new Request('http://localhost/personaldev'));
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Bucket name or file name is not set' });
+    });
+
+    test('GET /api/gcs/sampledev - Semi-Normal (環境変数未設定 → 400)', async () => {
+        delete process.env.GCS_SAMPLE_DATA_PATH;
+        const response = await gcsRouter.fetch(new Request('http://localhost/sampledev'));
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Bucket name or file name is not set' });
+    });
+
+    // ---- 異常系（Abnormal）: 想定外のエラー → 安全な失敗（500）----
+    test('GET /api/gcs/common - Abnormal (GCS download 例外 → 500)', async () => {
+        mockDownload.mockRejectedValueOnce(new Error('GCS unavailable'));
+        const response = await gcsRouter.fetch(new Request('http://localhost/common'));
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch data from GCS' });
+    });
+
+    test('GET /api/gcs/common - Abnormal (不正 JSON → 500)', async () => {
+        mockDownload.mockResolvedValueOnce([Buffer.from('this-is-not-json{')]);
+        const response = await gcsRouter.fetch(new Request('http://localhost/common'));
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch data from GCS' });
+    });
+
+    test('GET /api/gcs/personaldev - Abnormal (GCS download 例外 → 500)', async () => {
+        mockDownload.mockRejectedValueOnce(new Error('GCS unavailable'));
+        const response = await gcsRouter.fetch(new Request('http://localhost/personaldev'));
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch data from GCS' });
+    });
+
+    test('GET /api/gcs/sampledev - Abnormal (GCS download 例外 → 500)', async () => {
+        mockDownload.mockRejectedValueOnce(new Error('GCS unavailable'));
+        const response = await gcsRouter.fetch(new Request('http://localhost/sampledev'));
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch data from GCS' });
     });
 });

--- a/front/__tests__/api/mail.test.ts
+++ b/front/__tests__/api/mail.test.ts
@@ -26,8 +26,14 @@ function buildSendRequest(body: unknown, token = 'valid-token') {
 }
 
 describe('Mail Router - /send', () => {
+    beforeEach(() => {
+        // 異常系で意図的に発生する console.error はテスト出力から抑制する
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
 
     // 正常系
@@ -123,6 +129,40 @@ describe('Mail Router - /send', () => {
 
         expect(res.status).toBe(400);
         expect(await res.json()).toEqual({ error: 'Missing required fields' });
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    // 異常系: Resend 送信が例外を投げたら 500（安全な失敗）
+    test('POST /send - Abnormal: Resend 例外は 500', async () => {
+        mockSend.mockRejectedValueOnce(new Error('Resend unavailable'));
+        const res = await mailRouter.fetch(
+            buildSendRequest({
+                name: 'Taro',
+                email: 'taro@example.com',
+                subjects: 'Hello',
+                messages: 'Hi',
+            }),
+        );
+
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Failed to send email' });
+    });
+
+    // 異常系: リクエストボディが不正 JSON なら 500（CSRF は通過するが json() が投げる）
+    test('POST /send - Abnormal: 不正 JSON ボディは 500', async () => {
+        const req = new Request('http://localhost/send', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': JSON.stringify('valid-token'),
+                Cookie: 'csrfToken=valid-token',
+            },
+            body: '{ this is not valid json',
+        });
+        const res = await mailRouter.fetch(req);
+
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Failed to send email' });
         expect(mockSend).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## 概要

既存の API ユニットテスト（GCS / Mail）は **正常系・準正常系のみ**で、想定外エラー時の **500 パス（異常系）が未カバー**でした。mock で失敗を注入し、**正常系 / 準正常系 / 異常系の3系統を網羅**します。

## 変更点

### `gcs.test.ts`（6 → 10 ケース）
- `file().download()` を**制御可能な共有モック**（`mockDownload`）に変更し、`mockRejectedValueOnce` / `mockResolvedValueOnce` で失敗を注入できるように
- 異常系を追加: **download 例外 → 500**、**不正 JSON → 500**（`Failed to fetch data from GCS`）
- 内訳: 正常 3 / 準正常 3（環境変数未設定→400）/ 異常 4

### `mail.test.ts`（5 → 7 ケース）
- 異常系を追加: **Resend 例外 → 500**、**不正 JSON ボディ → 500**（`Failed to send email`）
- 内訳: 正常 1 / 準正常 4 / 異常 2

### その他
- 異常系で意図的に出る `console.error` は spy で抑制（CI ログのノイズ防止）
- `docs/08-test-specification.md`（テスト表を分類付きに刷新・件数更新）、`docs/11-tasks.md`（T-26）

## テスト分類の網羅（testing.md 準拠）
- 合計 **11 → 17 ケース**（正常 4 / 準正常 7 / 異常 6）。比率 約 1:3.2 で「正常1 : 異常2以上」を満たす
- モックは外部 I/O（GCS SDK / Resend / nanoid）のみ。ビジネスロジックはモックしない

## 検証（すべて green）
- ✅ `pnpm test` — **17/17**
- ✅ `pnpm format:check`（テストファイル含む）/ `pnpm lint`
- ✅ CI（`test.yml` の Run unit tests）で自動実行される

## 補足（スコープ外）
UT ゼロの領域（`utils` / `schema(Zod)` / `hooks` / components）は本 PR 対象外。次段として別途補強予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)