### PR TITLE
chore: ルートに Makefile を追加（README にコマンド対応表を併記）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,127 @@
+# Makefile — nextjs-hono-portal-web-app
+#
+# ルート直下から、front/ に集約したアプリ（Next.js + Hono）の pnpm スクリプトや
+# terraform/ の IaC 操作を、`cd` せずに実行するためのショートカット集。
+# コマンド一覧は `make` または `make help` で確認できる。
+
+FRONT := front
+TF    := terraform
+
+# front/ で pnpm スクリプトを実行するヘルパー
+PNPM  := pnpm --dir $(FRONT)
+
+.DEFAULT_GOAL := help
+
+# ---------------------------------------------------------------------------
+# セットアップ
+# ---------------------------------------------------------------------------
+
+.PHONY: install
+install: ## 依存をインストール（front/）
+	$(PNPM) install
+
+.PHONY: setup
+setup: ## .env の雛形を作成（front/.env.example → front/.env、既存は保持）
+	@if [ -f $(FRONT)/.env ]; then \
+		echo "$(FRONT)/.env は既に存在します（上書きしません）"; \
+	else \
+		cp $(FRONT)/.env.example $(FRONT)/.env && echo "$(FRONT)/.env を作成しました"; \
+	fi
+
+# ---------------------------------------------------------------------------
+# 開発 / ビルド
+# ---------------------------------------------------------------------------
+
+.PHONY: dev
+dev: ## 開発サーバ起動（http://localhost:3000）
+	$(PNPM) dev
+
+.PHONY: build
+build: ## 本番ビルド
+	$(PNPM) build
+
+.PHONY: start
+start: ## ビルド成果物を起動
+	$(PNPM) start
+
+# ---------------------------------------------------------------------------
+# 品質（Lint / Format）
+# ---------------------------------------------------------------------------
+
+.PHONY: lint
+lint: ## ESLint（src/）
+	$(PNPM) lint
+
+.PHONY: format
+format: ## Prettier で自動整形
+	$(PNPM) format
+
+.PHONY: format-check
+format-check: ## Prettier でチェックのみ（整形はしない）
+	$(PNPM) format:check
+
+# ---------------------------------------------------------------------------
+# テスト
+# ---------------------------------------------------------------------------
+
+.PHONY: test
+test: ## ユニットテスト（Jest）
+	$(PNPM) test
+
+.PHONY: test-watch
+test-watch: ## ユニットテスト（ウォッチモード）
+	$(PNPM) test:watch
+
+.PHONY: test-coverage
+test-coverage: ## ユニットテスト（カバレッジ付き）
+	$(PNPM) test:coverage
+
+.PHONY: test-it
+test-it: ## 統合テスト（fake-gcs-server 起動済み前提）
+	$(PNPM) test:it
+
+.PHONY: test-it-docker
+test-it-docker: ## 統合テスト（エミュレータ起動 → IT → 停止 を自動化）
+	$(PNPM) test:it:docker
+
+.PHONY: e2e
+e2e: ## E2E テスト（Playwright / ヘッドレス）
+	$(PNPM) test:e2e
+
+.PHONY: e2e-ui
+e2e-ui: ## E2E テスト（UI モード）
+	$(PNPM) test:e2e:ui
+
+.PHONY: e2e-headed
+e2e-headed: ## E2E テスト（ブラウザ表示）
+	$(PNPM) test:e2e:headed
+
+.PHONY: ci
+ci: format-check lint test test-it-docker ## CI 相当をローカルで実行（format:check → lint → UT → IT）
+
+# ---------------------------------------------------------------------------
+# Terraform（IaC）
+# ---------------------------------------------------------------------------
+
+.PHONY: tf-init
+tf-init: ## terraform init
+	terraform -chdir=$(TF) init
+
+.PHONY: tf-plan
+tf-plan: ## terraform plan
+	terraform -chdir=$(TF) plan
+
+.PHONY: tf-apply
+tf-apply: ## terraform apply
+	terraform -chdir=$(TF) apply
+
+# ---------------------------------------------------------------------------
+# ヘルプ
+# ---------------------------------------------------------------------------
+
+.PHONY: help
+help: ## このヘルプを表示
+	@echo "使い方: make <target>"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -133,17 +133,21 @@ pnpm dev
 
 ## よく使うコマンド
 
-> いずれも `front/` ディレクトリで実行します。
+> `pnpm` コマンドは `front/` ディレクトリで実行します。`make` コマンドは **ルート直下**で実行でき、内部で `front/` に委譲するため `cd` は不要です（全ターゲットは `make help` を参照）。
 
-| コマンド | 内容 |
-|---|---|
-| `pnpm dev` | 開発サーバ起動（http://localhost:3000） |
-| `pnpm build` | 本番ビルド |
-| `pnpm start` | ビルド成果物を起動 |
-| `pnpm lint` | ESLint（`src/`） |
-| `pnpm format` | Prettier で自動整形 / `pnpm format:check` でチェック |
-| `pnpm test` | Jest ユニットテスト（`test:watch` / `test:coverage` も可） |
-| `pnpm test:e2e` | Playwright E2E（`test:e2e:ui` / `test:e2e:headed` も可） |
+| pnpm（`front/`） | make（ルート） | 内容 |
+|---|---|---|
+| `pnpm install` | `make install` | 依存をインストール |
+| `pnpm dev` | `make dev` | 開発サーバ起動（http://localhost:3000） |
+| `pnpm build` | `make build` | 本番ビルド |
+| `pnpm start` | `make start` | ビルド成果物を起動 |
+| `pnpm lint` | `make lint` | ESLint（`src/`） |
+| `pnpm format` / `format:check` | `make format` / `make format-check` | Prettier で整形 / チェック |
+| `pnpm test` | `make test` | Jest ユニットテスト（`test-watch` / `test-coverage` も可） |
+| `pnpm test:it:docker` | `make test-it-docker` | 統合テスト（fake-gcs-server 自動起動〜停止） |
+| `pnpm test:e2e` | `make e2e` | Playwright E2E（`e2e-ui` / `e2e-headed` も可） |
+| — | `make ci` | CI 相当を一括実行（format:check → lint → UT → IT） |
+| — | `make tf-init` / `tf-plan` / `tf-apply` | Terraform（`terraform/`） |
 
 ## 環境変数
 


### PR DESCRIPTION
## 概要

ルート直下に `Makefile` を追加し、`front/` に集約したアプリの pnpm スクリプトや `terraform/` の IaC 操作を **`cd` せずにルートから実行**できるようにしました。

## 変更内容

- **`Makefile`（新規）**
  - `install` / `setup`（.env 雛形・既存は保持）/ `dev` / `build` / `start`
  - `lint` / `format` / `format-check`
  - `test` / `test-watch` / `test-coverage` / `test-it` / `test-it-docker` / `e2e` / `e2e-ui` / `e2e-headed`
  - `ci`（format:check → lint → UT → IT を一括、CI パイプライン相当）
  - `tf-init` / `tf-plan` / `tf-apply`
  - `make` / `make help`（self-documenting なヘルプ。既定ターゲット）
  - 実装方針: `pnpm --dir front` / `terraform -chdir=terraform` を使い、サブディレクトリへの `cd` 依存を排除。`.PHONY` 宣言済み。
- **`README.md`**: 「よく使うコマンド」に pnpm / make の対応表を併記。

## 動作確認

- `make help`（一覧表示）
- `make -n format-check` / `ci` / `tf-plan`（dry-run で委譲先コマンドを確認）
- `make format-check` を実スタックで実行 → `front/` で Prettier が走り pass

## ドキュメント（影響マップ）

- 「実行手順の変更 → README.md」に該当するため README を同一 PR 内で更新済み。
- テスト戦略・API・データモデル等の仕様変更はなく、他ドキュメントの更新は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)