### PR TITLE
chore(rules): TypeScript 固有規約と GitHub issue 運用ルールを追加

### DIFF
--- a/.claude/rules/github-issue.md
+++ b/.claude/rules/github-issue.md
@@ -1,0 +1,20 @@
+---
+description: GitHub issue 運用（ブランチと対で issue を作成し open/close で進捗管理）
+globs: 
+---
+
+# GitHub issue 運用
+
+開発の作業単位を GitHub issue で管理する。
+
+- **issue 起票**: 開発を開始する際、作業ブランチを切るのと対で、対応する GitHub issue を作成する（作業単位 = 1 issue）。
+- **進捗管理**: issue の状態で進捗を表す。
+  - **対応中**: issue は open のままにする。
+  - **完了**: 対応する PR のマージで issue をクローズする（下記の自動クローズを使う）。
+- **ブランチとの紐付け**: ブランチ名は GitHub Flow の命名規約（feat/*, fix/*, chore/* 等）に従い、対応する issue を PR で参照する。
+- **PR での自動クローズ**: PR 本文に `Closes #<issue番号>`（バグ修正は `Fixes #<issue番号>`）を記載し、マージ時に issue を自動クローズする。
+- **粒度**: 1 issue = 1 PR で閉じられるまとまった作業を基本とする。
+- **サブ issue（作業を分割する場合）**: 作業が大きく大枠・中枠・小枠に分かれる場合は、大枠を親 issue、中枠・小枠をサブ issue として起票する。
+  - 親 issue に、サブ issue へのリンクをチェックリスト（`- [ ] #<番号>`）で列挙し、進捗を集約する（GitHub のサブ issue 機能を使ってもよい）。
+  - 各サブ issue も通常どおりブランチ・PR と対応させ、PR の `Closes #<サブissue番号>` でクローズする。全サブ issue が閉じたら親 issue を閉じる。
+  - 分割が不要な小さい作業は単一 issue でよい（無理に親子化しない）。

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,167 @@
+---
+description: TypeScript コーディング規約 — type/interface の使い分け・型定義の配置等、TS 固有の指針
+globs: front/src/**
+---
+
+# TypeScript コーディング規約
+
+共通の `coding-standards.md` に加え、TypeScript 固有の指針を定める。命名規則は Linter 既定に委ね、本書では扱わない。
+
+## type vs interface
+
+**原則 `type` を使う。** 以下の 2 条件のいずれかに当たる場合のみ `interface` を使う。
+
+- **条件 1: class 契約** — その型を **class が `implements` / `extends` する**
+  - サービス契約・リポジトリポート・DI 抽象など
+  - → NestJS のような**クラス中心の層**で主に該当
+- **条件 2: 宣言マージが必要** — 型を**後から拡張する**必要がある
+  - ライブラリ型の拡張（`declare module 'express' { interface Request { user?: AuthUser } }`）
+  - グローバル型の拡張（`declare global { interface Window { ... } }`）
+  - 公開ライブラリとして**利用者に拡張させる**型
+  - → `type` は宣言マージできないため、ここは `interface` でしか実現できない
+- **`type` を使う**（上記以外すべて）
+  - class が絡まないオブジェクト形状（props・DTO・レスポンス型）
+  - union / 交差 / tuple / 関数型 / mapped・conditional 型などの型演算
+  - → React / Vue / Hono のような**関数・データ中心の層**
+
+宣言マージは「意図せず型が拡張され得る」副作用でもある。**アプリ内部の型に `interface` を選ぶ理由にはしない**（条件 1 か、外部から拡張される前提の型に限る）。
+
+```ts
+// 条件 1: class 契約 → interface（NestJS 等）
+interface TaskRepository {
+  findById(id: string): Promise<Task | null>;
+}
+
+@Injectable()
+class PrismaTaskRepository implements TaskRepository {
+  /* ... */
+}
+
+// 条件 2: 宣言マージ → interface
+declare module 'hono' {
+  interface ContextVariableMap {
+    currentUser: AuthUser;
+  }
+}
+
+// それ以外 → type（FE データ・union・関数型）
+type TaskStatus = 'todo' | 'doing' | 'done';
+type TaskProps = { id: string; title: string; status: TaskStatus };
+type OnSelect = (id: string) => void;
+```
+
+**補足**: NestJS の DTO は `class-validator` デコレータを付けるため **class** で定義する（type/interface ではない）。本節は「型定義」に対する指針であり、バリデーション用 DTO クラスは対象外。
+
+## 型定義の配置（コロケーション / `types/` 集約）
+
+型を各ファイルに散在させず、**参照範囲**で置き場所を決める。判断軸は「**その型を参照するファイルが 1 つに閉じるか**」。
+
+| 参照範囲 | 置き場所 |
+|---|---|
+| **1 ファイルに閉じる** | その定義ファイル内にコロケーション（`export` しない） |
+| **2 ファイル以上** / レイヤ・機能をまたぐ | `types/` に集約して `export` |
+
+### 運用ルール
+
+- **最初から `types/` に置かない。** まず定義ファイル内に書き、**2 箇所目の参照が発生した時点で `types/` へ昇格**させる。先回りの集約は、使われない共通型と不要な依存を増やす。
+- **昇格時は元ファイルに型を残さない**（re-export も含む）。定義は常に 1 箇所。
+- `types/` はドメイン単位でファイルを分ける（`types/task.ts` / `types/user.ts`）。1 ファイルに全ドメインを詰めない。
+- **barrel（`types/index.ts` からの一括 re-export）は作らない。** 循環参照・バンドル肥大・tree-shaking 阻害の原因になる。`import type { Task } from '@/types/task'` と**実ファイルを直接 import** する。
+
+### 分類の目安
+
+- **`types/` に置く**: API レスポンス/リクエスト型、ドメインエンティティ、複数画面で共有する union リテラル、共通のユーティリティ型
+- **コロケーションのまま**: コンポーネントの props 型（コンポーネントと 1:1 で、UI の変更と同時に変わる）、そのファイル内でしか使わない内部型・引数オブジェクト型
+
+```ts
+// コンポーネント固有 → コロケーション（export しない）
+type TaskCardProps = { task: Task; onSelect: (id: string) => void };
+export function TaskCard({ task, onSelect }: TaskCardProps) { /* ... */ }
+
+// 複数箇所から参照 → types/task.ts に集約
+// types/task.ts
+export type TaskStatus = 'todo' | 'doing' | 'done';
+export type Task = { id: string; title: string; status: TaskStatus };
+```
+
+### 型へのコメント
+
+`type` / `interface` は**型本体・各メンバーともにコメント必須**。詳細は `jsdoc.md`（必須対象・記述ルール）に従う。
+
+## 定数の配置（`constants/` 集約）
+
+**マジックナンバー・マジック文字列を直接書かない。** 分岐条件・API パス・ストレージキー・上限値・リトライ回数などのリテラルは名前付き定数にする。名前が付いていない値は、検索もできず変更漏れも検出できない。
+
+置き場所は型と**同じ「参照範囲」の軸**で決める。
+
+| 参照範囲 | 置き場所 |
+|---|---|
+| **1 ファイルに閉じる** | その定義ファイルの先頭で `const` 宣言（`export` しない） |
+| **2 ファイル以上** / レイヤ・機能をまたぐ | `constants/` に集約して `export` |
+
+### 運用ルール
+
+- **`lib/` や `utils/` に定数を混ぜない。** 「関数の置き場」と「値の置き場」を分けると、変更時に探す範囲が狭まる。
+- 昇格の運用は型と同じ: まず使う場所に書き、**2 箇所目の参照が発生した時点で `constants/` へ移す**。移動時は元ファイルに残さない（re-export も含む）。
+- `constants/` はドメイン単位でファイルを分ける（`constants/task.ts` / `constants/api.ts`）。**barrel（`constants/index.ts`）は作らない**（理由は型と同じ）。
+- **`as const` を付ける。** 付けないとリテラル型が `string` / `number` に広がり、union の導出や補完が効かなくなる。
+- 命名は `UPPER_SNAKE_CASE`。オブジェクト定数のキーも同様に揃える。
+
+### 型の元になる定数は「型と同じファイル」に置く
+
+union リテラルの元になる配列・オブジェクトは、**導出される型とセットで `types/` 側に置く**。`constants/` と `types/` に分けると、値と型が常に往復参照になり、片方だけ更新される事故が起きる。
+
+```ts
+// types/task.ts — 値と型はペアで同居させる
+/** タスクの進行状態。表示順もこの配列の順序に従う。 */
+export const TASK_STATUSES = ['todo', 'doing', 'done'] as const;
+/** タスクの進行状態。遷移は配列順の一方向のみ */
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+// constants/task.ts — 型を導出しない純粋な値はこちら
+/** 一覧の 1 ページあたり件数。API 側の上限（100）を超えない */
+export const TASK_PAGE_SIZE = 20;
+```
+
+### 環境変数は定数ではない
+
+環境ごとに値が変わるもの（API のベース URL、キー、フィーチャーフラグ）を `constants/` に置かない。ビルド時に特定環境の値が埋め込まれ、環境差異の事故につながる。**設定は env スキーマ経由で読み込む層**（`config/` 等）に分離する。`constants/` に置くのは**全環境で不変な値**だけ。
+
+### 定数へのコメント
+
+`export` された定数は**コメント必須**（`jsdoc.md`）。特に**単位**（`TIMEOUT_MS` がミリ秒であること）と**その値である根拠**（「API 側の上限が 100 のため」）を書く。根拠のない数値は、後から誰も変更してよいか判断できない。
+
+## any 禁止・unknown 優先
+
+- **暗黙・明示を問わず `any` を禁止**する（`noImplicitAny` 前提）。
+- 外部入力（API レスポンス・`JSON.parse`・ユーザー入力）は **`unknown` で受け**、型ガード・スキーマ検証（zod 等）で**ナローイング**してから使う。
+- どうしても `any` が必要な箇所は根拠コメントを残す（「as/! 抑制」節参照）。
+
+## enum 回避・union リテラル + as const
+
+- `enum` より **union リテラル型**＋必要なら **`as const`** を優先する。
+- 理由: `enum` はランタイムにオブジェクトを生成しバンドルに残る／tree-shaking されにくい／`const enum` は分離コンパイルで問題が出る。union リテラルは型のみで**ランタイムコストゼロ**。
+
+```ts
+// 非推奨
+enum Status { Todo, Doing, Done }
+// 推奨
+const STATUSES = ['todo', 'doing', 'done'] as const;
+type Status = (typeof STATUSES)[number];
+```
+
+## import type 強制
+
+- 型だけを import する場合は **`import type`** を使う（値と型を混ぜない）。
+- 理由: バンドラ／トランスパイラが型を確実に消せる、副作用のない循環参照を避けられる。`verbatimModuleSyntax` 有効化を推奨。
+
+```ts
+import type { User } from './user';
+import { createUser } from './user';
+```
+
+## as / ! 抑制
+
+- 型アサーション `as` と non-null assertion `!` を**最小化**する。まず型ガード・早期 return・オプショナルチェーンで解決する。
+- 使う場合は**根拠コメント必須**（なぜ安全か／なぜ必要か）。`as unknown as` / `as any` / `@ts-ignore` / `@ts-expect-error` の根拠記述は `jsdoc.md`（混乱テスト）と接続する。
+- `as const`（リテラル固定）はここでの「アサーション」に含まない（推奨用途）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,10 @@ Next.js + Hono によるポータルWebアプリケーション（フロント�
 | documentation.md | 全体 | ドキュメント更新ルール |
 | doc-structure.md | 全体 | docs ファイルサイズ上限（150行）・分割・index |
 | git.md | 全体 | GitHub Flow・ブランチ命名・push 禁止物 |
+| github-issue.md | 全体 | GitHub issue 運用（ブランチと対で起票・open/close で進捗管理・PR で自動クローズ） |
 | testing.md | 全体 | テスト分類・原則・テストツール（Jest / Playwright） |
 | coding-standards.md | 全体 | コーディング規約（TypeScript strict・pnpm・ESLint/Prettier） |
+| typescript.md | `front/src/**` | TypeScript 固有規約（type/interface 使い分け・型/定数の配置・any 禁止・enum 回避・import type） |
 | error-handling.md | 全体 | エラーハンドリング方針（バリデーション・例外・ログ） |
 | security.md | 全体 | セキュリティ設計方針（認証・CORS・インジェクション対策・シークレット管理） |
 | jsdoc.md | `front/src/**` | JSDoc（TSDoc）規約（公開シンボルに必須） |


### PR DESCRIPTION
## 概要

テックスタック（一体型 Next.js + Hono）確定に伴い、未整備だったスタック依存ルールを `.claude/rules/` に追加し、CLAUDE.md の Rules テーブルを同期する（`/rules-update` スキル実行）。

## 変更点

- **`typescript.md`（新規, scope: `front/src/**`）**: TypeScript 固有規約。type/interface の使い分け・型/定数の配置（コロケーション/集約）・any 禁止/unknown 優先・enum 回避・import type 強制・as/! 抑制。
- **`github-issue.md`（新規, 全体）**: GitHub issue 駆動開発の運用。ブランチと対で起票・open/close で進捗管理・PR `Closes #N` で自動クローズ・サブ issue 運用。
- **`CLAUDE.md`**: Rules テーブルに上記 2 ルールを追記。

## 意図的にスキップした項目

- 既存の調整済みルール（`api.md`/`frontend.md`/`coding-standards.md`/`jsdoc.md` 等）は上書きせず据え置き（プロジェクト固有の記述を保持するため）。
- `testing.md` への追記は見送り。テンプレが Vitest 前提のため、実際の Jest + Playwright 構成と矛盾するため。
- `database.md`・言語別ルールは対象スタックなし（ORM 不使用・TypeScript 単一）。

## ドキュメント影響（documentation.md 影響マップ）

`.claude/rules/` の追加 → CLAUDE.md（Rules テーブル）を同一 PR 内で更新済み。他ドキュメントへの影響なし。

## 確認してほしい点

- 追加した 2 ルールの内容・粒度がプロジェクト方針と整合しているか。
- `typescript.md` の scope glob（`front/src/**`）が `jsdoc.md` と揃っているか。

🤖 Generated with [Claude Code](https://claude.com/claude-code)