### PR TITLE
refactor(ts): 型安全性の是正（any撲滅・unknown受け・import type強制）

### DIFF
--- a/front/e2e/tests/api/send-mail.spec.ts
+++ b/front/e2e/tests/api/send-mail.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
 
 // CSRFトークン取得用の関数
 async function getCsrfToken(request: APIRequestContext) {

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -3,6 +3,18 @@ import jsdoc from "eslint-plugin-jsdoc";
 
 export default [
   ...nextConfig,
+  // 型のみの import を `import type` に強制する（typescript.md「import type 強制」）。
+  // verbatimModuleSyntax（tsc オプション）は CI で tsc を実行しないため強制できないので、
+  // CI が実行する lint 側で機械強制する。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "separate-type-imports" },
+      ],
+    },
+  },
   // JSDoc（TSDoc スタイル）規約の、機械的に判定できる部分を強制する。
   // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
   {

--- a/front/src/app/api/gcs/gcs.ts
+++ b/front/src/app/api/gcs/gcs.ts
@@ -16,9 +16,9 @@ const gcsRouter = new Hono();
  * GCSからJSONファイルを取得する
  * @param bucketName GCSのバケット名
  * @param fileName GCSのJSONファイルのパス
- * @returns JSONファイルの内容
+ * @returns JSONファイルの内容（任意の JSON のため unknown。呼び出し側で検証する）
  */
-async function fetchJsonFromGCS(bucketName: string, fileName: string): Promise<any> {
+async function fetchJsonFromGCS(bucketName: string, fileName: string): Promise<unknown> {
     try {
         const bucket = storage.bucket(bucketName);
         const file = bucket.file(fileName);

--- a/front/src/app/components/page-transition/PageTransition.tsx
+++ b/front/src/app/components/page-transition/PageTransition.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 interface PageTransitionProps {
     children: ReactNode;

--- a/front/src/app/contact/confirm/page.tsx
+++ b/front/src/app/contact/confirm/page.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 // types
-import { contactFormData } from '@/app/types/contact-types';
+import type { contactFormData } from '@/app/types/contact-types';
 // schema
 import { contactSchema } from '@/app/schema/contact-schema';
 // utils

--- a/front/src/app/contact/form/page.tsx
+++ b/front/src/app/contact/form/page.tsx
@@ -7,12 +7,13 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 // shadcn
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 // types
-import { contactFormData } from '@/app/types/contact-types';
+import type { contactFormData } from '@/app/types/contact-types';
 // schema
 import { contactSchema } from '@/app/schema/contact-schema';
 // utils
@@ -27,6 +28,9 @@ import { setFormError } from '@/app/utils/form/form-utils';
 import Navbar from '@/app/components/nav-bar/Navbar';
 import PageTransition from '@/app/components/page-transition/PageTransition';
 import Footer from '@/app/components/layout/Footer';
+
+/** `/api/mail/csrf` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const csrfResponseSchema = z.object({ csrfToken: z.string() });
 
 /**
  * お問い合わせペォームページ
@@ -55,8 +59,13 @@ const ContactFormPage = () => {
                 const response = await fetch('/api/mail/csrf', {
                     credentials: 'include', // クッキーを送信するために必要
                 });
-                const data = await response.json();
-                setCsrfToken(data.csrfToken);
+                const data: unknown = await response.json();
+                const parsed = csrfResponseSchema.safeParse(data);
+                if (parsed.success) {
+                    setCsrfToken(parsed.data.csrfToken);
+                } else {
+                    console.error('Unexpected CSRF response format:', data);
+                }
             } catch (error) {
                 console.error('CSRF token fetch error:', error);
             }

--- a/front/src/app/contexts/CommonContext.tsx
+++ b/front/src/app/contexts/CommonContext.tsx
@@ -1,8 +1,21 @@
 'use client';
 
-import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { z } from 'zod';
 // types
 import type { CommonDataType } from '@/app/types/common-data-types';
+
+/** `/api/gcs/common` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const commonResponseSchema = z.object({
+    portfolio: z.object({ url: z.string() }),
+    blog: z.object({ url: z.string() }),
+    link: z.object({
+        github: z.string(),
+        x: z.string(),
+        linkedin: z.string(),
+    }),
+});
 
 /** 共通データ Context の状態。`isLoading` は取得中フラグ、`commonData` は取得結果（未取得時は null）。 */
 type CommonDataState = {
@@ -48,16 +61,23 @@ export const CommonDataProvider: React.FC<CommonDataProviderProps> = ({ children
                 const result = await fetch(`/api/gcs/common`);
 
                 if (result.ok) {
-                    const data = await result.json();
-                    setCommonData({
-                        portfolioUrl: data.portfolio.url,
-                        blogUrl: data.blog.url,
-                        linkUrl: {
-                            githubUrl: data.link.github,
-                            xUrl: data.link.x,
-                            linkedinUrl: data.link.linkedin,
-                        },
-                    });
+                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
+                    const data: unknown = await result.json();
+                    const parsed = commonResponseSchema.safeParse(data);
+                    if (parsed.success) {
+                        const { portfolio, blog, link } = parsed.data;
+                        setCommonData({
+                            portfolioUrl: portfolio.url,
+                            blogUrl: blog.url,
+                            linkUrl: {
+                                githubUrl: link.github,
+                                xUrl: link.x,
+                                linkedinUrl: link.linkedin,
+                            },
+                        });
+                    } else {
+                        console.error('Unexpected common data format:', data);
+                    }
                 }
             } catch (error) {
                 console.error('Error fetching common data:', error);

--- a/front/src/app/personaldev/page.tsx
+++ b/front/src/app/personaldev/page.tsx
@@ -5,10 +5,23 @@ import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { PulseLoader } from 'react-spinners';
+import { z } from 'zod';
 // types
-import { PersonalDevDataType } from '@/app/types/personal-data-types';
+import type { PersonalDevDataType } from '@/app/types/personal-data-types';
 // utils
 import { useIsHomePath } from '@/app/utils/path/path-functions';
+
+/** `/api/gcs/personaldev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const personalDevResponseSchema = z.object({
+    personaldev: z.array(
+        z.object({
+            title: z.string(),
+            description: z.string(),
+            tech: z.array(z.string()),
+            url: z.string(),
+        }),
+    ),
+});
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import Footer from '@/app/components/layout/Footer';
@@ -30,17 +43,11 @@ const PersonalHistoryDevPage = () => {
                 const result = await fetch('/api/gcs/personaldev');
 
                 if (result.ok) {
-                    const data = await result.json();
-
-                    if (data.personaldev && Array.isArray(data.personaldev)) {
-                        setPersonalDevDataList(
-                            data.personaldev.map((item: any) => ({
-                                title: item.title,
-                                description: item.description,
-                                tech: item.tech,
-                                url: item.url,
-                            })),
-                        );
+                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
+                    const data: unknown = await result.json();
+                    const parsed = personalDevResponseSchema.safeParse(data);
+                    if (parsed.success) {
+                        setPersonalDevDataList(parsed.data.personaldev);
                     } else {
                         console.error('Unexpected API response format:', data);
                     }

--- a/front/src/app/sampledev/page.tsx
+++ b/front/src/app/sampledev/page.tsx
@@ -6,10 +6,24 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { PulseLoader } from 'react-spinners';
 import Image from 'next/image';
+import { z } from 'zod';
 // types
-import { SampleDevDataType } from '@/app/types/sample-data-types';
+import type { SampleDevDataType } from '@/app/types/sample-data-types';
 // utils
 import { useIsHomePath } from '@/app/utils/path/path-functions';
+
+/** `/api/gcs/sampledev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const sampleDevResponseSchema = z.object({
+    sampledev: z.array(
+        z.object({
+            title: z.string(),
+            description: z.string(),
+            tech: z.array(z.string()),
+            imageUrl: z.string(),
+            url: z.string(),
+        }),
+    ),
+});
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import PageTransition from '@/app/components/page-transition/PageTransition';
@@ -31,18 +45,11 @@ const SampleHistoryDevPage = () => {
                 const result = await fetch('/api/gcs/sampledev');
 
                 if (result.ok) {
-                    const data = await result.json();
-
-                    if (data.sampledev && Array.isArray(data.sampledev)) {
-                        setSampleDevDataList(
-                            data.sampledev.map((item: any) => ({
-                                title: item.title,
-                                description: item.description,
-                                tech: item.tech,
-                                imageUrl: item.imageUrl,
-                                url: item.url,
-                            })),
-                        );
+                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
+                    const data: unknown = await result.json();
+                    const parsed = sampleDevResponseSchema.safeParse(data);
+                    if (parsed.success) {
+                        setSampleDevDataList(parsed.data.sampledev);
                     } else {
                         console.error('Unexpected API response format:', data);
                     }

--- a/front/src/app/types/contact-types.ts
+++ b/front/src/app/types/contact-types.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import { contactSchema } from '@/app/schema/contact-schema';
+import type { z } from 'zod';
+import type { contactSchema } from '@/app/schema/contact-schema';
 
 /**
  * お問い合わせフォームデータ

--- a/front/src/app/utils/form/form-utils.ts
+++ b/front/src/app/utils/form/form-utils.ts
@@ -1,4 +1,4 @@
-import { FieldValues, UseFormSetError } from 'react-hook-form';
+import type { FieldValues, UseFormSetError } from 'react-hook-form';
 
 /**
  * フォームエラーを設定


### PR DESCRIPTION
## 概要

親 issue #84 の #77。`any` を撲滅し、外部入力（fetch 応答）を `unknown` で受けて zod で検証してから使う形へ是正。型のみ import を `import type` に統一し、lint で機械強制する。

Closes #77

## 変更点

- **`gcs.ts`**: `fetchJsonFromGCS` の戻り値を `Promise<any>` → `Promise<unknown>`（呼び出し側で検証する契約に）。
- **`personaldev/page.tsx` / `sampledev/page.tsx` / `CommonContext.tsx` / `contact/form/page.tsx`**: `await res.json()` を `unknown` で受け、**co-located の zod スキーマ**で `safeParse` してからナローイング。`(item: any) => ...` の手動 map を排除。検証失敗時は `console.error` でログしフォールバック。
- **型のみ import を `import type` 化**: `ReactNode`（PageTransition / CommonContext）・`FieldValues`/`UseFormSetError`（form-utils）・各 `XxxDataType`・`contactFormData`・`z`/`contactSchema`（contact-types）。
- **lint 強制**: `eslint.config.mjs` に `@typescript-eslint/consistent-type-imports` を追加（`src/**`）。

## 設計判断: verbatimModuleSyntax → ESLint ルール

issue では `verbatimModuleSyntax: true` を挙げていたが、以下の理由で **ESLint ルールに変更**した:
1. `verbatimModuleSyntax` は tsc オプションで、**本 CI は tsc を実行しない**ため強制されない（狙いは「lint で機械強制」）。
2. ts-jest の CommonJS 出力と衝突し `TS1286` でユニットテストが全滅する。

`@typescript-eslint/consistent-type-imports` は `pnpm lint`（CI 実行）で強制でき、ts-jest も壊さないため、狙いをより確実に達成する。

## テスト結果（ローカル）
- `npx tsc --noEmit`: クリーン
- `pnpm format:check` / `pnpm lint`（新ルール込み） / `pnpm test`（20/20）: すべて通過
- E2E: モック（`e2e/tests/mock/*.json`）が新 zod スキーマの形状と一致することを確認済み（空配列・500 応答も既存の `result.ok` ガードで安全）。CI で最終確認。

## ドキュメント影響
機能・API・データ仕様の変更なし（内部型安全性の是正）。typescript.md は既に import type / unknown 受けを規定済みのため spec 更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)