### PR TITLE
test: 曖昧アサーション除去と異常系比率の是正

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 # reports
 jest-report/
 playwright-report/
+test-results/

--- a/front/__tests__/it/gcs.it.test.ts
+++ b/front/__tests__/it/gcs.it.test.ts
@@ -55,4 +55,26 @@ describe('GCS Router (IT: fake-gcs-server 実結合)', () => {
         expect(res.status).toBe(500);
         expect(await res.json()).toEqual({ error: 'Failed to fetch data from GCS' });
     });
+
+    test('GET /personaldev - 異常系: 存在しないオブジェクト → 500', async () => {
+        process.env.GCS_PERSONAL_DATA_PATH = 'does-not-exist.json';
+        const res = await gcsRouter.fetch(new Request('http://localhost/personaldev'));
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Failed to fetch data from GCS' });
+    });
+
+    test('GET /sampledev - 異常系: 存在しないオブジェクト → 500', async () => {
+        process.env.GCS_SAMPLE_DATA_PATH = 'does-not-exist.json';
+        const res = await gcsRouter.fetch(new Request('http://localhost/sampledev'));
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Failed to fetch data from GCS' });
+    });
+
+    // ---- 準正常系（Semi-Normal）: 個別ルートの環境変数未設定 → 400 ----
+    test('GET /personaldev - 準正常系: 環境変数未設定 → 400', async () => {
+        delete process.env.GCS_PERSONAL_DATA_PATH;
+        const res = await gcsRouter.fetch(new Request('http://localhost/personaldev'));
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: 'Bucket name or file name is not set' });
+    });
 });

--- a/front/e2e/tests/api/send-mail.spec.ts
+++ b/front/e2e/tests/api/send-mail.spec.ts
@@ -4,7 +4,7 @@ import type { APIRequestContext } from '@playwright/test';
 // CSRFトークン取得用の関数
 async function getCsrfToken(request: APIRequestContext) {
     const response = await request.get('/api/mail/csrf');
-    expect(response.ok()).toBeTruthy();
+    expect(response.status()).toBe(200);
     const data = await response.json();
     return {
         csrfToken: data.csrfToken,
@@ -15,7 +15,7 @@ async function getCsrfToken(request: APIRequestContext) {
 test.describe('Mail API tests', () => {
     test('GET /api/mail/csrf - get csrfToken', async ({ request }) => {
         const response = await request.get('/api/mail/csrf');
-        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
 
         const data = await response.json();
         expect(data).toHaveProperty('csrfToken');

--- a/front/e2e/tests/pages/contact-success.spec.ts
+++ b/front/e2e/tests/pages/contact-success.spec.ts
@@ -42,4 +42,20 @@ test.describe('Contact Success Page', () => {
         await page.getByRole('link', { name: '再度お問い合わせ' }).click();
         await expect(page).toHaveURL('/contact/form');
     });
+
+    // 異常系: 共通データ取得が 500 でも完了画面はクラッシュせず表示される
+    test('共通データ取得失敗（500）でも表示される', async ({ page }) => {
+        await page.route('**/api/gcs/common', async (route) => {
+            await route.fulfill({
+                status: 500,
+                contentType: 'application/json',
+                body: JSON.stringify({ error: 'Failed to fetch data from GCS' }),
+            });
+        });
+
+        await page.goto('/contact/success');
+
+        await page.waitForSelector('text=送信が完了しました！');
+        await expect(page.getByRole('heading', { name: '送信が完了しました！' })).toBeVisible();
+    });
 });

--- a/front/e2e/tests/pages/hello.spec.ts
+++ b/front/e2e/tests/pages/hello.spec.ts
@@ -3,5 +3,5 @@ import { test, expect } from '@playwright/test';
 // 動作確認用のe2eテスト
 test('Top page is displayed', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveTitle(/.*/);
+    await expect(page).toHaveTitle('My Developers Hub');
 });

--- a/front/e2e/tests/scenarios/contact-flow.spec.ts
+++ b/front/e2e/tests/scenarios/contact-flow.spec.ts
@@ -67,6 +67,33 @@ test('お問い合わせ: 入力 → 確認 → 送信完了 の一連フロー'
     await expect(page.getByRole('heading', { name: '送信が完了しました！' })).toBeVisible();
 });
 
+// 異常系: 一連フローで送信が 500 失敗したら、完了画面へ遷移せず確認画面にエラーを表示する
+test('お問い合わせ: 入力 → 確認 → 送信失敗（500）は完了画面へ遷移しない', async ({ page }) => {
+    // beforeEach の成功モックを 500 で上書きする
+    await page.route('**/api/mail/send', async (route) => {
+        await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Failed to send email' }),
+        });
+    });
+
+    await page.goto('/contact/form');
+    await fillForm(page);
+    await page.click('button[type="submit"]');
+    await page.waitForURL('**/contact/confirm');
+
+    await page.getByRole('button', { name: '確認して送信' }).click();
+    await page.waitForSelector('text=本当に送信してもよろしいでしょうか？');
+    await page.getByRole('button', { name: '送信する' }).click();
+
+    // エラー表示 & success へ遷移しない
+    await expect(
+        page.locator('p.text-red-500', { hasText: 'エラーが発生しました。' }),
+    ).toBeVisible();
+    await expect(page).toHaveURL('/contact/confirm');
+});
+
 test('お問い合わせ: 入力 → 確認 → 修正 → 再入力 → 送信完了 の往復フロー', async ({ page }) => {
     // 1. 入力して確認画面へ
     await page.goto('/contact/form');

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     // テストの実行環境
     webServer: {
         // テストの実行環境のコマンド
-        command: 'npm run dev',
+        command: 'pnpm dev',
         // テストの実行環境のURL
         url: 'http://localhost:3000',
         // テストの実行環境の再利用

--- a/front/test-results/.last-run.json
+++ b/front/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## 概要

親 issue #84 の #78。testing.md が名指しで禁止する曖昧アサーションを除去し、異常系を追加して比率を是正する。

Closes #78

## 変更点

### 曖昧アサーション・規約是正（機械的）
- **`send-mail.spec.ts`**: `expect(response.ok()).toBeTruthy()` × 2 → `expect(response.status()).toBe(200)`（testing.md 名指し禁止）。
- **`hello.spec.ts`**: `toHaveTitle(/.*/)`（任意マッチ）→ `toHaveTitle('My Developers Hub')`（具体値）。
- **`playwright.config.ts`**: webServer の `npm run dev` → `pnpm dev`（coding-standards.md の pnpm 規約）。

### 異常系の追加（実カバレッジ）
- **`gcs.it.test.ts`**: `/personaldev`・`/sampledev` の 500（存在しないオブジェクト）、`/personaldev` の env 未設定 400 を追加。IT の正常:異常 = 3:2 → **3:5**。
- **`contact-flow.spec.ts`**: 一連フローで送信 500 失敗時に完了画面へ遷移せずエラー表示する異常系を追加。
- **`contact-success.spec.ts`**: 共通データ 500 でもグレースフルに表示される異常系を追加。

## 比率についての方針
testing.md の 1:2 は「目安」。UT/IT/API 層は既に充足。E2E ページ表示層は**意味のある異常系（送信失敗・グレースフル劣化）を追加**し、比率を機械的に満たすための contrived なテストは作らない方針とした（testing.md「テストは仕様の証明」に沿う）。home/contact-confirm/contact-form は既に異常系を保持しているため据え置き。

なお **contact-success 画面にはフォームデータのガードが無く**（無条件表示）、監査で挙がった「未設定で直接アクセス時のフォールバック」は該当実装がないため、代わりに共通データ失敗のグレースフル劣化を追加した。

## テスト結果（ローカル）
- `tsc --noEmit` / `pnpm format:check` / `pnpm lint` / `pnpm test`(20/20): 通過
- `pnpm test:it:docker`: **8/8 passed**（fake-gcs-server 実結合）
- 追加した E2E 異常系（contact-flow 送信500・contact-success 共通500）: ローカルで通過確認
- `send-mail.spec` はローカルに `.env` が無く dev サーバーが Resend key 不在でクラッシュするため見かけ上 fail するが、CI では `.env.test` により通る（#77 CI 実績あり）。CI で最終確認。

## ドキュメント影響
テスト戦略・分類は不変（既存方針内での異常系強化）。docs/08 は既に pnpm 記載のため更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)