### PR TITLE
docs(jsdoc): 公開 API ハンドラー等への JSDoc 補強

### DIFF
--- a/front/src/app/api/gcs/gcs.ts
+++ b/front/src/app/api/gcs/gcs.ts
@@ -9,14 +9,16 @@ const storage = new Storage(
         ? { apiEndpoint: process.env.GCS_API_ENDPOINT, projectId: 'local-emulator' }
         : undefined,
 );
-// Honoのインスタンスを作成
+/** GCS からデータ（共通 / 個人開発 / サンプル開発）を取得するサブルーター（`/api/gcs` 配下にマウント）。 */
 const gcsRouter = new Hono();
 
 /**
- * GCSからJSONファイルを取得する
- * @param bucketName GCSのバケット名
- * @param fileName GCSのJSONファイルのパス
- * @returns JSONファイルの内容（任意の JSON のため unknown。呼び出し側で検証する）
+ * GCS から JSON ファイルを取得してパースする。
+ *
+ * @param bucketName - GCS のバケット名
+ * @param fileName - GCS の JSON ファイルのパス
+ * @returns JSON ファイルの内容（任意の JSON のため unknown。呼び出し側で検証する）
+ * @throws {Error} ダウンロードまたは JSON パースに失敗した場合
  */
 async function fetchJsonFromGCS(bucketName: string, fileName: string): Promise<unknown> {
     try {
@@ -35,12 +37,22 @@ async function fetchJsonFromGCS(bucketName: string, fileName: string): Promise<u
     }
 }
 
-// 動作確認用のエンドポイント
+/**
+ * GCS API の疎通確認用エンドポイント。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 接続確認メッセージ（200）
+ */
 gcsRouter.get('/', (c) => {
     return c.json({ message: 'Connected to GCS API' });
 });
 
-// 実際に GCS から JSON を取得するエンドポイント
+/**
+ * 共通データ（ポートフォリオ / ブログ / SNS リンク）を GCS から取得して返す。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 共通データ JSON（200）。バケット名/パス未設定は 400、取得失敗は 500。
+ */
 gcsRouter.get('/common', async (c) => {
     try {
         const bucketName = process.env.GCS_PRIVATE_BUCKET_NAME;
@@ -58,6 +70,12 @@ gcsRouter.get('/common', async (c) => {
     }
 });
 
+/**
+ * 個人開発データを GCS から取得して返す。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 個人開発データ JSON（200）。バケット名/パス未設定は 400、取得失敗は 500。
+ */
 gcsRouter.get('/personaldev', async (c) => {
     try {
         const bucketName = process.env.GCS_PRIVATE_BUCKET_NAME;
@@ -75,6 +93,12 @@ gcsRouter.get('/personaldev', async (c) => {
     }
 });
 
+/**
+ * サンプル開発データを GCS から取得して返す。
+ *
+ * @param c - Hono コンテキスト
+ * @returns サンプル開発データ JSON（200）。バケット名/パス未設定は 400、取得失敗は 500。
+ */
 gcsRouter.get('/sampledev', async (c) => {
     try {
         const bucketName = process.env.GCS_PRIVATE_BUCKET_NAME;

--- a/front/src/app/api/mail/mail.ts
+++ b/front/src/app/api/mail/mail.ts
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid';
 import { getCookie, setCookie } from 'hono/cookie';
 import { contactSchema } from '@/app/schema/contact-schema';
 
-// Honoのインスタンスを作成
+/** CSRF トークン発行とメール送信を担うサブルーター（`/api/mail` 配下にマウント）。 */
 const mailRouter = new Hono();
 // Resendクライアントの初期化
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -27,7 +27,12 @@ const escapeHtml = (value: string): string =>
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
 
-// CSRFトークンを発行するエンドポイント
+/**
+ * CSRF トークンを発行し、HttpOnly Cookie にセットして返す。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 発行した CSRF トークン（200）。同トークンを HttpOnly Cookie にもセットする。
+ */
 mailRouter.get('/csrf', (c) => {
     const csrfToken = nanoid(32);
     setCookie(c, 'csrfToken', csrfToken, {
@@ -60,12 +65,25 @@ const csrfMiddleware: MiddlewareHandler = async (c, next) => {
     await next();
 };
 
-// 動作確認用のエンドポイント
+/**
+ * Mail API の疎通確認用エンドポイント。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 接続確認メッセージ（200）
+ */
 mailRouter.get('/', (c) => {
     return c.json({ message: 'Connected to Mail API' });
 });
 
-// メール送信のエンドポイント
+/**
+ * お問い合わせ内容をメール送信する（CSRF ミドルウェアで保護）。
+ *
+ * リクエストは共有スキーマ（contactSchema）で検証し、HTML 本文はエスケープして
+ * インジェクションを防ぐ。
+ *
+ * @param c - Hono コンテキスト
+ * @returns 送信結果（200）。入力不正・メール設定欠落は 400、CSRF 不正は 403、送信失敗は 500。
+ */
 mailRouter.post('/send', csrfMiddleware, async (c) => {
     try {
         // c.req.json() は any を返すため unknown 相当で受け、共有スキーマ（クライアントと同一）で検証する。

--- a/front/src/app/components/hero/Hero.tsx
+++ b/front/src/app/components/hero/Hero.tsx
@@ -6,7 +6,6 @@ import { useCommonData } from '@/app/contexts/CommonContext';
 
 /**
  * ヒーローセクション
- * @returns JSX.Element
  */
 const Hero = () => {
     const { isLoading, commonData } = useCommonData();

--- a/front/src/app/components/layout/Footer.tsx
+++ b/front/src/app/components/layout/Footer.tsx
@@ -7,7 +7,6 @@ import { useCommonData } from '@/app/contexts/CommonContext';
 
 /**
  * フッター
- * @returns JSX.Element
  */
 const Footer = () => {
     const currentYear = new Date().getFullYear();

--- a/front/src/app/components/nav-bar/Navbar.tsx
+++ b/front/src/app/components/nav-bar/Navbar.tsx
@@ -9,7 +9,6 @@ import { useCommonData } from '@/app/contexts/CommonContext';
 
 /**
  * ナビゲーションバー
- * @returns JSX.Element
  */
 const Navbar = () => {
     const [isOpen, setIsOpen] = useState(false);

--- a/front/src/app/components/page-transition/PageTransition.tsx
+++ b/front/src/app/components/page-transition/PageTransition.tsx
@@ -3,14 +3,14 @@
 import { motion } from 'framer-motion';
 import type { ReactNode } from 'react';
 
+/** ページ遷移アニメーションのラッパーが受け取る props。 */
 interface PageTransitionProps {
+    /** アニメーションを適用する子要素 */
     children: ReactNode;
 }
 
 /**
- * ページ遷移時のアニメーション
- * @param children 子要素
- * @returns JSX.Element
+ * ページ遷移時にフェードアニメーションを子要素へ適用するラッパー。
  */
 const PageTransition = ({ children }: PageTransitionProps) => {
     return (

--- a/front/src/app/contact/confirm/page.tsx
+++ b/front/src/app/contact/confirm/page.tsx
@@ -28,7 +28,6 @@ import ConfirmModal from '@/app/components/modal/ConfirmModal';
 
 /**
  * お問い合わせ確認ページ
- * @returns JSX.Element
  */
 const ContactConfirmPage = () => {
     const isHome: boolean = useIsHomePath();

--- a/front/src/app/contact/form/page.tsx
+++ b/front/src/app/contact/form/page.tsx
@@ -34,7 +34,6 @@ const csrfResponseSchema = z.object({ csrfToken: z.string() });
 
 /**
  * お問い合わせペォームページ
- * @returns JSX.Element
  */
 const ContactFormPage = () => {
     const isHome: boolean = useIsHomePath();
@@ -92,7 +91,7 @@ const ContactFormPage = () => {
 
     /**
      * 送信
-     * @param data フォームデータ
+     * @param data - フォームデータ
      */
     const onSubmit = async (data: contactFormData) => {
         try {

--- a/front/src/app/contact/success/page.tsx
+++ b/front/src/app/contact/success/page.tsx
@@ -12,7 +12,6 @@ import PageTransition from '@/app/components/page-transition/PageTransition';
 
 /**
  * 送信成功画面
- * @returns JSX.Element
  */
 const ContactSuccessPage = () => {
     const isHome: boolean = useIsHomePath();

--- a/front/src/app/hooks/useModal.ts
+++ b/front/src/app/hooks/useModal.ts
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
 /**
- * モーダルのカスタムhooks
- * @returns モーダルのhooks
+ * 確認モーダルの開閉状態と操作ハンドラーを提供するカスタムフック。
+ *
+ * @returns モーダルの開閉状態（`isModalOpen`）と、開く/実行/閉じるの各ハンドラー
  */
 export const useModal = () => {
     // モーダルの開閉状態

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
 };
 
 /**
- * ルートレイアウト
- * @param children 子要素
- * @returns JSX.Element
+ * ルートレイアウト。全ページ共通の HTML 骨格と共通データ Provider を提供する。
+ *
+ * @param children - ページ本体の要素
  */
 export default function RootLayout({
     children,

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -11,7 +11,6 @@ import PageTransition from '@/app/components/page-transition/PageTransition';
 
 /**
  * ホームページ
- * @returns JSX.Element
  */
 export default function Home() {
     const isHome: boolean = useIsHomePath();

--- a/front/src/app/personaldev/page.tsx
+++ b/front/src/app/personaldev/page.tsx
@@ -29,7 +29,6 @@ import PageTransition from '@/app/components/page-transition/PageTransition';
 
 /**
  * 個人開発履歴ページ
- * @returns JSX.Element
  */
 const PersonalHistoryDevPage = () => {
     const isHome: boolean = useIsHomePath();

--- a/front/src/app/sampledev/page.tsx
+++ b/front/src/app/sampledev/page.tsx
@@ -31,7 +31,6 @@ import Footer from '@/app/components/layout/Footer';
 
 /**
  * サンプル開発履歴ページ
- * @returns JSX.Element
  */
 const SampleHistoryDevPage = () => {
     const isHome: boolean = useIsHomePath();

--- a/front/src/app/utils/form/form-utils.ts
+++ b/front/src/app/utils/form/form-utils.ts
@@ -2,8 +2,8 @@ import type { FieldValues, UseFormSetError } from 'react-hook-form';
 
 /**
  * フォームエラーを設定
- * @param error エラー
- * @param setError エラー設定関数
+ * @param error - エラー
+ * @param setError - エラー設定関数
  */
 export const setFormError = <T extends FieldValues>(
     error: unknown,

--- a/front/src/app/utils/session/session-utils.ts
+++ b/front/src/app/utils/session/session-utils.ts
@@ -1,6 +1,6 @@
 /**
  * セッションストレージからデータを取得
- * @param key キー
+ * @param key - キー
  * @returns データ
  */
 export const getDataBySessionStorage = (key: string) => {
@@ -13,8 +13,8 @@ export const getDataBySessionStorage = (key: string) => {
 
 /**
  * セッションストレージにデータを保存
- * @param key キー
- * @param data データ
+ * @param key - キー
+ * @param data - データ
  */
 export const setDataBySessionStorage = (key: string, data: unknown) => {
     sessionStorage.setItem(key, JSON.stringify(data));
@@ -22,7 +22,7 @@ export const setDataBySessionStorage = (key: string, data: unknown) => {
 
 /**
  * セッションストレージからデータを削除
- * @param key キー
+ * @param key - キー
  */
 export const removeDataBySessionStorage = (key: string) => {
     sessionStorage.removeItem(key);


### PR DESCRIPTION
## 概要

親 issue #84 の #79。jsdoc.md の「公開シンボルに JSDoc 必須」に対し、API ルートハンドラー群に JSDoc が皆無だったのを補強し、あわせて低優先の体裁不備（型再掲・@param 区切り）を整理する。

Closes #79

## 変更点

### API ハンドラーの JSDoc（主目的）
- **`gcs.ts`**: `gcsRouter` と各ルート（`/`,`/common`,`/personaldev`,`/sampledev`）に JSDoc を付与。`@param c` / `@returns` に 200/400/500 の方針を明記。`fetchJsonFromGCS` に `@throws` を追記し `@param` を `-` 区切りへ。
- **`mail.ts`**: `mailRouter` と各ルート（`/csrf`,`/`,`/send`）に JSDoc を付与。

### props 型（中）
- **`PageTransitionProps`**: 型と `children` プロパティに説明を付与。

### 体裁整理（低）
- 各コンポーネントの `@returns JSX.Element`（型再掲でノイズ）を除去。`.tsx` は eslint 設定で `require-returns` 対象外のため lint は通る。
- `session-utils` / `form-utils` / `layout` / `contact-form` の `@param` を `@param name - 説明` の規約形式へ正規化。
- `useModal`: 循環的だった `@returns 説明`（「モーダルの hooks」）を具体化。

## 設計メモ
Hono ハンドラー（`router.get('/x', (c) => ...)`）への JSDoc は、`@param c` / `@returns` を含めても eslint-plugin-jsdoc の `require-param` / `check-param-names` と競合しないことをローカル lint で確認済み。

## テスト結果（ローカル）
- `tsc --noEmit` / `pnpm format:check` / `pnpm lint`（jsdoc ルール込み） / `pnpm test`(20/20): すべて通過。
- 変更は JSDoc（コメント）のみで実行時挙動・API・データに影響なし。

## ドキュメント影響
JSDoc（コメント）のみの変更で、機能・API・データ・テスト戦略の変更なし。spec 更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)