### PR TITLE
refactor(ts): interface→type 統一とマジック値の定数集約

### DIFF
--- a/front/src/app/api/mail/mail.ts
+++ b/front/src/app/api/mail/mail.ts
@@ -7,6 +7,11 @@ import { contactSchema } from '@/app/schema/contact-schema';
 
 /** CSRF トークン発行とメール送信を担うサブルーター（`/api/mail` 配下にマウント）。 */
 const mailRouter = new Hono();
+
+/** CSRF トークンの長さ（文字数）。推測を困難にするのに十分な長さ。 */
+const CSRF_TOKEN_LENGTH = 32;
+/** CSRF トークンを保持する Cookie 名。送信検証時に同名 Cookie と照合する。 */
+const CSRF_COOKIE_NAME = 'csrfToken';
 // Resendクライアントの初期化
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -34,8 +39,8 @@ const escapeHtml = (value: string): string =>
  * @returns 発行した CSRF トークン（200）。同トークンを HttpOnly Cookie にもセットする。
  */
 mailRouter.get('/csrf', (c) => {
-    const csrfToken = nanoid(32);
-    setCookie(c, 'csrfToken', csrfToken, {
+    const csrfToken = nanoid(CSRF_TOKEN_LENGTH);
+    setCookie(c, CSRF_COOKIE_NAME, csrfToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'Strict',
@@ -47,7 +52,7 @@ mailRouter.get('/csrf', (c) => {
 // トークンを検証するミドルウェア
 const csrfMiddleware: MiddlewareHandler = async (c, next) => {
     const csrfTokenFromHeader = c.req.header('x-csrf-token')?.trim();
-    const csrfTokenFromCookie = getCookie(c, 'csrfToken')?.trim();
+    const csrfTokenFromCookie = getCookie(c, CSRF_COOKIE_NAME)?.trim();
 
     // ヘッダーは JSON 文字列で送られてくる。不正な JSON は検証失敗（403）として扱い、
     // JSON.parse の例外が 500 として漏れないようにする。

--- a/front/src/app/components/modal/ConfirmModal.tsx
+++ b/front/src/app/components/modal/ConfirmModal.tsx
@@ -1,11 +1,11 @@
-interface ConfirmModalProps {
+type ConfirmModalProps = {
     /** モーダルの開閉状態 */
     isOpen: boolean;
     /** モーダルを閉じる処理 */
     onClose: () => void;
     /** モーダルでの「送信する」ボタン押下時の処理 */
     onConfirm: () => void;
-}
+};
 
 /**
  * 確認モーダル。props の詳細は {@link ConfirmModalProps} を参照。

--- a/front/src/app/components/page-transition/PageTransition.tsx
+++ b/front/src/app/components/page-transition/PageTransition.tsx
@@ -4,10 +4,10 @@ import { motion } from 'framer-motion';
 import type { ReactNode } from 'react';
 
 /** ページ遷移アニメーションのラッパーが受け取る props。 */
-interface PageTransitionProps {
+type PageTransitionProps = {
     /** アニメーションを適用する子要素 */
     children: ReactNode;
-}
+};
 
 /**
  * ページ遷移時にフェードアニメーションを子要素へ適用するラッパー。

--- a/front/src/app/constants/storage.ts
+++ b/front/src/app/constants/storage.ts
@@ -1,0 +1,11 @@
+/**
+ * クライアントの sessionStorage キー。
+ * お問い合わせフォームの入力値と CSRF トークンの一時保持に使う。
+ * サーバー側の Cookie 名（mail API の CSRF Cookie）とは別管理。
+ */
+export const STORAGE_KEYS = {
+    /** お問い合わせフォームの入力値 */
+    CONTACT_FORM: 'contactFormData',
+    /** CSRF トークン（クライアント保持分） */
+    CSRF_TOKEN: 'csrfToken',
+} as const;

--- a/front/src/app/contact/confirm/page.tsx
+++ b/front/src/app/contact/confirm/page.tsx
@@ -10,6 +10,8 @@ import { ArrowLeft } from 'lucide-react';
 import type { contactFormData } from '@/app/types/contact-types';
 // schema
 import { contactSchema } from '@/app/schema/contact-schema';
+// constants
+import { STORAGE_KEYS } from '@/app/constants/storage';
 // utils
 import {
     getDataBySessionStorage,
@@ -51,10 +53,10 @@ const ContactConfirmPage = () => {
 
     useEffect(() => {
         // sessionStorage から CSRFトークンを取得
-        const storedToken = sessionStorage.getItem('csrfToken');
+        const storedToken = sessionStorage.getItem(STORAGE_KEYS.CSRF_TOKEN);
         setCsrfToken(storedToken || null);
 
-        const data = getDataBySessionStorage('contactFormData');
+        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
         if (!data) {
             router.push('/contact/form');
             return;
@@ -80,7 +82,7 @@ const ContactConfirmPage = () => {
             });
 
             if (response.ok) {
-                removeDataBySessionStorage('contactFormData');
+                removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
                 router.push('/contact/success');
             } else {
                 setFormError(response.statusText, setError);
@@ -93,8 +95,8 @@ const ContactConfirmPage = () => {
     const handleBackToForm = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
 
-        removeDataBySessionStorage('contactFormData');
-        removeDataBySessionStorage('csrfToken');
+        removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
+        removeDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN);
         sessionStorage.clear();
         router.replace('/contact/form');
     };

--- a/front/src/app/contact/form/page.tsx
+++ b/front/src/app/contact/form/page.tsx
@@ -16,6 +16,8 @@ import { Label } from '@/components/ui/label';
 import type { contactFormData } from '@/app/types/contact-types';
 // schema
 import { contactSchema } from '@/app/schema/contact-schema';
+// constants
+import { STORAGE_KEYS } from '@/app/constants/storage';
 // utils
 import { useIsHomePath } from '@/app/utils/path/path-functions';
 // utils
@@ -73,7 +75,7 @@ const ContactFormPage = () => {
         fetchCsrfToken();
 
         // セッションストレージからデータを取得
-        const data = getDataBySessionStorage('contactFormData');
+        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
         if (data) {
             reset(data);
         }
@@ -100,8 +102,8 @@ const ContactFormPage = () => {
             }
 
             // セッションストレージにデータを保存
-            setDataBySessionStorage('contactFormData', data);
-            setDataBySessionStorage('csrfToken', csrfToken);
+            setDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM, data);
+            setDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN, csrfToken);
 
             // 確認画面へ遷移
             router.push('/contact/confirm');

--- a/front/src/app/contexts/CommonContext.tsx
+++ b/front/src/app/contexts/CommonContext.tsx
@@ -41,10 +41,10 @@ export const useCommonData = () => {
 };
 
 // Props
-interface CommonDataProviderProps {
+type CommonDataProviderProps = {
     /** Provider 配下に共通データを供給する子要素 */
     children: ReactNode;
-}
+};
 
 /**
  * 共通データ（ポートフォリオ / ブログ / SNS リンク）を GCS から取得して配下に供給する Provider。


### PR DESCRIPTION
## 概要

親 issue #84 の #80。props 型の `interface` を `type` に寄せ、複数箇所に散るマジック値を集約する。値は不変で挙動に影響しない純粋なリファクタ。

Closes #80

## 変更点
- **interface→type**: `ConfirmModalProps` / `PageTransitionProps` / `CommonDataProviderProps`（class 契約でも宣言マージでもないため `type`）。
- **定数集約**: sessionStorage キー `'contactFormData'` / `'csrfToken'` を `src/app/constants/storage.ts` の `STORAGE_KEYS`（`as const`）へ集約し、contact/form・contact/confirm で共有。
- **mail.ts**: CSRF Cookie 名（`CSRF_COOKIE_NAME`）と nanoid のトークン長（`CSRF_TOKEN_LENGTH`）を根拠コメント付き定数へ。Cookie 名はサーバー1ファイルに閉じるため co-locate。

## 設計メモ
`'csrfToken'` は「クライアント sessionStorage キー」と「サーバー Cookie 名」の2用途があるが参照ドメインが異なるため別定数として扱った。定数の**値は不変**のため実行時挙動は変わらない。

## テスト結果（ローカル）
- `tsc --noEmit` / `pnpm format:check` / `pnpm lint` / `pnpm test`(20/20): 通過
- src に `interface` ゼロ・マジック値ゼロ（定数定義を除く）を確認

## ドキュメント影響
型・定数の内部整理で API・機能・データ変更なし。spec 更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)