### PR TITLE
feat(security): セキュリティヘッダー（CSP / HSTS 等）の付与

### DIFF
--- a/docs/06-security-specification.md
+++ b/docs/06-security-specification.md
@@ -14,9 +14,10 @@
   - [クライアントサイド](#クライアントサイド)
   - [サーバーサイド](#サーバーサイド)
 - [4. 外部リンクのセキュリティ](#4-外部リンクのセキュリティ)
-- [5. インフラレベルのセキュリティ](#5-インフラレベルのセキュリティ)
-- [6. 環境変数（セキュリティ関連）](#6-環境変数セキュリティ関連)
-- [7. セキュリティ監査](#7-セキュリティ監査)
+- [5. HTTP セキュリティヘッダー](#5-http-セキュリティヘッダー)
+- [6. インフラレベルのセキュリティ](#6-インフラレベルのセキュリティ)
+- [7. 環境変数（セキュリティ関連）](#7-環境変数セキュリティ関連)
+- [8. セキュリティ監査](#8-セキュリティ監査)
 
 ## 1. CORS（Cross-Origin Resource Sharing）
 
@@ -91,7 +92,25 @@ cors({
 - すべての外部リンク（`target="_blank"`）に `rel="noopener noreferrer"` を付与
 - 外部URLのXSS防止
 
-## 5. インフラレベルのセキュリティ
+## 5. HTTP セキュリティヘッダー
+
+`front/next.config.mjs` の `headers()` で全レスポンス（`/:path*`）に付与する（多層防御）。
+
+| ヘッダー | 値（要約） | 目的 |
+|---------|-----------|------|
+| `Content-Security-Policy` | `default-src 'self'` を基点。script/style は `'unsafe-inline'`（Next.js ハイドレーション・framer-motion 由来）、img は `'self' data: https:` | XSS の緩和 |
+| `X-Frame-Options` | `DENY` | クリックジャッキング防止（CSP `frame-ancestors 'none'` と二重化） |
+| `X-Content-Type-Options` | `nosniff` | MIME スニッフィング防止 |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラ漏洩の抑制 |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | HTTPS 強制（HSTS） |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 不要な機能 API の無効化 |
+
+### 補足
+
+- CSP は nonce 方式ではなく `'unsafe-inline'` を許容する妥協実装（Next.js のインラインスクリプト/スタイル都合）。`'unsafe-eval'` は開発時（HMR）のみ許可し、本番では外す。
+- HSTS は http 応答では無視されるため、開発・E2E には影響しない。
+
+## 6. インフラレベルのセキュリティ
 
 | レイヤー | 対策 |
 |---------|------|
@@ -101,7 +120,7 @@ cors({
 | Docker | alpineベースの最小イメージ |
 | GitHub Actions | Secretsによる機密情報管理 |
 
-## 6. 環境変数（セキュリティ関連）
+## 7. 環境変数（セキュリティ関連）
 
 | 変数名 | 説明 |
 |--------|------|
@@ -110,7 +129,7 @@ cors({
 | `MY_MAIL_ADDRESS` | メール送信先アドレス |
 | `RESEND_SEND_DOMAIN` | Resend送信ドメイン |
 
-## 7. セキュリティ監査
+## 8. セキュリティ監査
 
 2026-01-31にnpm auditを実施。18件の脆弱性を検出し、10件を修正済み。
 残存する8件はNext.js/ESLintのメジャーアップグレードが必要。

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -1,24 +1,51 @@
 /** @type {import('next').NextConfig} */
+
+// 本番判定。開発サーバー（`next dev`）は HMR が eval を使うため CSP を一部緩める。
+const isProd = process.env.NODE_ENV === 'production';
+
+// Content-Security-Policy（多層防御の一層 = XSS 対策）。
+// Next.js はハイドレーション用インラインスクリプトと styled-jsx / framer-motion のインライン
+// スタイルを使うため 'unsafe-inline' が必要。開発時のみ HMR 用に 'unsafe-eval' を許可し、
+// 本番では外す（nonce 方式は未導入のため現状の妥協点）。
+const cspDirectives = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  // 画像は自ドメイン・data URI・任意の https（開発履歴データの外部画像 URL を許容）
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  `script-src 'self' 'unsafe-inline'${isProd ? '' : " 'unsafe-eval'"}`,
+  "connect-src 'self'",
+];
+const contentSecurityPolicy = cspDirectives.join('; ');
+
+// 全レスポンスに付与するセキュリティヘッダー（security.md: HTTPS 強制・XSS・クリックジャッキング対策）。
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  // HTTPS 強制（HSTS）。http 応答では無視されるため dev/E2E に影響しない。
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
 const nextConfig = {
   images: {
     unoptimized: true,
   },
-  // images: {
-  //   domains: ['storage.googleapis.com', 'images.unsplash.com'],
-  //   remotePatterns: [
-  //     {
-  //       protocol: 'https',
-  //       hostname: 'images.unsplash.com',
-  //       pathname: '/**',
-  //     },
-  //     {
-  //       protocol: 'https',
-  //       hostname: 'storage.googleapis.com',
-  //       pathname: '/intro_k_pub_bucket/**',
-  //     },
-  //   ],
-  // },
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要

親 issue #84 の #82。security.md の多層防御（XSS 対策の CSP・HTTPS 強制の HSTS）に対し、`next.config.mjs` にセキュリティヘッダーが未設定だったのを補う。

Closes #82

## 変更点
- **`next.config.mjs`**: `headers()` で全レスポンス（`/:path*`）に付与:
  - `Content-Security-Policy` / `X-Frame-Options: DENY` / `X-Content-Type-Options: nosniff` / `Referrer-Policy` / `Strict-Transport-Security`（HSTS）/ `Permissions-Policy`
- **`docs/06-security-specification.md`**: 「5. HTTP セキュリティヘッダー」節を追加（既存節を繰り下げ、136 行で 150 行以内）。

## CSP の方針（妥協点）
Next.js はハイドレーション用インラインスクリプトと framer-motion / styled-jsx のインラインスタイルを使うため、`script-src` / `style-src` に `'unsafe-inline'` を許容する。開発サーバー（`next dev`、E2E が使用）は HMR が eval を使うため `'unsafe-eval'` を **開発時のみ** 許可し、本番では外す（`NODE_ENV` で分岐）。nonce 方式は未導入。

## テスト結果（ローカル）
- ページ/シナリオ E2E を **新 CSP 適用の dev サーバー**に対して実行: **30/30 passed**（CSP がハイドレーション・描画を壊さないことを確認）。
- `pnpm lint` / `pnpm test`(20/20) / next.config.mjs 構文チェック: 通過。
- CI で全 E2E を最終確認。

## ドキュメント影響（documentation.md 影響マップ）
セキュリティ仕様の変更 → `docs/06-security-specification.md` を同一 PR で更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)