### PR TITLE
refactor(front): クライアントロジックの hooks 切り出しと配置整理

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -14,6 +14,8 @@ globs: "front/src/app/**,front/src/components/**,front/src/lib/**"
 | **アトミックデザイン** | Atoms / Molecules / Organisms / Pages | 小〜中規模・ドメインが少ない |
 | **ドメイン別構成** | features/ 配下にドメイン単位で分割 | 中〜大規模・ドメインが多い |
 
+> 補足: 現状は小規模（コンポーネント数が少ない）ため、`app/components/` 配下を**機能種類別のフラット構成**（`hero/` `layout/` `modal/` `nav-bar/` 等）とし、汎用 UI プリミティブは `components/ui/`（shadcn）に置く。規模拡大時は上記いずれかのパターンへ移行する。
+
 ## サーバー/クライアント分離
 
 - **server-first** を基本とする。データ取得・SEO はサーバーコンポーネントで行う。

--- a/front/src/app/contact/confirm/page.tsx
+++ b/front/src/app/contact/confirm/page.tsx
@@ -1,26 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
-// types
-import type { contactFormData } from '@/app/types/contact-types';
-// schema
-import { contactSchema } from '@/app/schema/contact-schema';
-// constants
-import { STORAGE_KEYS } from '@/app/constants/storage';
-// utils
-import {
-    getDataBySessionStorage,
-    removeDataBySessionStorage,
-} from '@/app/utils/session/session-utils';
-import { useIsHomePath } from '@/app/utils/path/path-functions';
-// utils
-import { setFormError } from '@/app/utils/form/form-utils';
 // hooks
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
+import { useContactConfirm } from '@/app/hooks/useContactConfirm';
 import { useModal } from '@/app/hooks/useModal';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
@@ -29,77 +13,14 @@ import PageTransition from '@/app/components/page-transition/PageTransition';
 import ConfirmModal from '@/app/components/modal/ConfirmModal';
 
 /**
- * お問い合わせ確認ページ
+ * お問い合わせ確認ページ。復元・送信・戻る処理は useContactConfirm に委譲する。
  */
 const ContactConfirmPage = () => {
     const isHome: boolean = useIsHomePath();
-    const router = useRouter();
-
-    // CSRFトークン
-    const [csrfToken, setCsrfToken] = useState<string | null>(null);
+    const { register, handleSubmit, watch, errors, onSubmit, handleBackToForm } =
+        useContactConfirm();
     // モーダル
     const { isModalOpen, handleOpenModal, handleExecute, handleCloseModal } = useModal();
-    // フォーム
-    const {
-        register,
-        handleSubmit,
-        reset,
-        watch,
-        setError,
-        formState: { errors },
-    } = useForm<contactFormData>({
-        resolver: zodResolver(contactSchema),
-    });
-
-    useEffect(() => {
-        // sessionStorage から CSRFトークンを取得
-        const storedToken = sessionStorage.getItem(STORAGE_KEYS.CSRF_TOKEN);
-        setCsrfToken(storedToken || null);
-
-        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
-        if (!data) {
-            router.push('/contact/form');
-            return;
-        }
-
-        reset(data);
-    }, [router, reset]);
-
-    const onSubmit = async (data: contactFormData) => {
-        try {
-            if (!csrfToken) {
-                throw new Error('CSRF token is missing.');
-            }
-
-            const response = await fetch('/api/mail/send', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': csrfToken,
-                },
-                credentials: 'include',
-                body: JSON.stringify(data),
-            });
-
-            if (response.ok) {
-                removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
-                router.push('/contact/success');
-            } else {
-                setFormError(response.statusText, setError);
-            }
-        } catch (error) {
-            setFormError(error, setError);
-        }
-    };
-
-    const handleBackToForm = (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault();
-
-        removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
-        removeDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN);
-        sessionStorage.clear();
-        router.replace('/contact/form');
-    };
 
     const itemVariants = {
         hidden: { opacity: 0, y: 20 },

--- a/front/src/app/contact/form/page.tsx
+++ b/front/src/app/contact/form/page.tsx
@@ -1,85 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 // shadcn
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-// types
-import type { contactFormData } from '@/app/types/contact-types';
-// schema
-import { contactSchema } from '@/app/schema/contact-schema';
-// constants
-import { STORAGE_KEYS } from '@/app/constants/storage';
-// utils
-import { useIsHomePath } from '@/app/utils/path/path-functions';
-// utils
-import {
-    getDataBySessionStorage,
-    setDataBySessionStorage,
-} from '@/app/utils/session/session-utils';
-import { setFormError } from '@/app/utils/form/form-utils';
+// hooks
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
+import { useContactForm } from '@/app/hooks/useContactForm';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import PageTransition from '@/app/components/page-transition/PageTransition';
 import Footer from '@/app/components/layout/Footer';
 
-/** `/api/mail/csrf` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
-const csrfResponseSchema = z.object({ csrfToken: z.string() });
-
 /**
- * お問い合わせペォームページ
+ * お問い合わせフォームページ。フォームの状態・送信ロジックは useContactForm に委譲する。
  */
 const ContactFormPage = () => {
     const isHome: boolean = useIsHomePath();
-    // ルーティング
-    const router = useRouter();
-    // CSRFトークン
-    const [csrfToken, setCsrfToken] = useState<string | null>(null);
-    // フォーム
-    const {
-        register,
-        handleSubmit,
-        formState: { errors },
-        setError,
-        reset,
-    } = useForm<contactFormData>({
-        resolver: zodResolver(contactSchema),
-    });
-
-    useEffect(() => {
-        const fetchCsrfToken = async () => {
-            try {
-                const response = await fetch('/api/mail/csrf', {
-                    credentials: 'include', // クッキーを送信するために必要
-                });
-                const data: unknown = await response.json();
-                const parsed = csrfResponseSchema.safeParse(data);
-                if (parsed.success) {
-                    setCsrfToken(parsed.data.csrfToken);
-                } else {
-                    console.error('Unexpected CSRF response format:', data);
-                }
-            } catch (error) {
-                console.error('CSRF token fetch error:', error);
-            }
-        };
-
-        fetchCsrfToken();
-
-        // セッションストレージからデータを取得
-        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
-        if (data) {
-            reset(data);
-        }
-    }, [router, reset]);
+    const { register, handleSubmit, errors, onSubmit } = useContactForm();
 
     const formVariants = {
         hidden: { opacity: 0 },
@@ -89,27 +30,6 @@ const ContactFormPage = () => {
                 staggerChildren: 0.1,
             },
         },
-    };
-
-    /**
-     * 送信
-     * @param data - フォームデータ
-     */
-    const onSubmit = async (data: contactFormData) => {
-        try {
-            if (!csrfToken) {
-                throw new Error('CSRF token is missing.');
-            }
-
-            // セッションストレージにデータを保存
-            setDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM, data);
-            setDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN, csrfToken);
-
-            // 確認画面へ遷移
-            router.push('/contact/confirm');
-        } catch (error) {
-            setFormError(error, setError);
-        }
     };
 
     const itemVariants = {

--- a/front/src/app/contact/success/page.tsx
+++ b/front/src/app/contact/success/page.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 // utils
-import { useIsHomePath } from '@/app/utils/path/path-functions';
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import Footer from '@/app/components/layout/Footer';

--- a/front/src/app/hooks/useContactConfirm.ts
+++ b/front/src/app/hooks/useContactConfirm.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { MouseEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { contactFormData } from '@/app/types/contact-types';
+import { contactSchema } from '@/app/schema/contact-schema';
+import { STORAGE_KEYS } from '@/app/constants/storage';
+import {
+    getDataBySessionStorage,
+    removeDataBySessionStorage,
+} from '@/app/utils/session/session-utils';
+import { setFormError } from '@/app/utils/form/form-utils';
+
+/**
+ * お問い合わせ確認画面の状態と送信処理を提供するフック。
+ *
+ * マウント時に sessionStorage から入力値と CSRF トークンを復元する（入力が無ければフォームへ戻す）。
+ * 送信時は `/api/mail/send` へ POST し、成功で完了画面、失敗でフォームエラーを表示する。
+ *
+ * @returns フォーム登録・監視関数、送信/戻るハンドラー、バリデーションエラー
+ */
+export const useContactConfirm = () => {
+    const router = useRouter();
+    // CSRFトークン
+    const [csrfToken, setCsrfToken] = useState<string | null>(null);
+    const {
+        register,
+        handleSubmit,
+        reset,
+        watch,
+        setError,
+        formState: { errors },
+    } = useForm<contactFormData>({
+        resolver: zodResolver(contactSchema),
+    });
+
+    useEffect(() => {
+        // sessionStorage から CSRFトークンを取得
+        const storedToken = sessionStorage.getItem(STORAGE_KEYS.CSRF_TOKEN);
+        setCsrfToken(storedToken || null);
+
+        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
+        if (!data) {
+            router.push('/contact/form');
+            return;
+        }
+
+        reset(data);
+    }, [router, reset]);
+
+    /**
+     * 確認内容をメール送信する。成功で完了画面、失敗でフォームエラーを設定する。
+     *
+     * @param data - 送信するフォームデータ
+     */
+    const onSubmit = async (data: contactFormData) => {
+        try {
+            if (!csrfToken) {
+                throw new Error('CSRF token is missing.');
+            }
+
+            const response = await fetch('/api/mail/send', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                },
+                credentials: 'include',
+                body: JSON.stringify(data),
+            });
+
+            if (response.ok) {
+                removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
+                router.push('/contact/success');
+            } else {
+                setFormError(response.statusText, setError);
+            }
+        } catch (error) {
+            setFormError(error, setError);
+        }
+    };
+
+    /**
+     * フォームへ戻る。保存済みの入力とトークンを破棄する。
+     *
+     * @param e - クリックイベント（デフォルト遷移を抑止する）
+     */
+    const handleBackToForm = (e: MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+
+        removeDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
+        removeDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN);
+        sessionStorage.clear();
+        router.replace('/contact/form');
+    };
+
+    return { register, handleSubmit, watch, errors, onSubmit, handleBackToForm };
+};

--- a/front/src/app/hooks/useContactForm.ts
+++ b/front/src/app/hooks/useContactForm.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import type { contactFormData } from '@/app/types/contact-types';
+import { contactSchema } from '@/app/schema/contact-schema';
+import { STORAGE_KEYS } from '@/app/constants/storage';
+import {
+    getDataBySessionStorage,
+    setDataBySessionStorage,
+} from '@/app/utils/session/session-utils';
+import { setFormError } from '@/app/utils/form/form-utils';
+
+/** `/api/mail/csrf` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const csrfResponseSchema = z.object({ csrfToken: z.string() });
+
+/**
+ * お問い合わせフォームの状態と送信処理を提供するフック。
+ *
+ * マウント時に CSRF トークンを取得し、保存済み入力があれば復元する。送信時は入力値と
+ * トークンを sessionStorage へ保存して確認画面へ遷移する（実送信は確認画面で行う）。
+ *
+ * @returns フォーム登録関数・送信ハンドラー・バリデーションエラー
+ */
+export const useContactForm = () => {
+    const router = useRouter();
+    // CSRFトークン
+    const [csrfToken, setCsrfToken] = useState<string | null>(null);
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+        setError,
+        reset,
+    } = useForm<contactFormData>({
+        resolver: zodResolver(contactSchema),
+    });
+
+    useEffect(() => {
+        const fetchCsrfToken = async () => {
+            try {
+                const response = await fetch('/api/mail/csrf', {
+                    credentials: 'include', // クッキーを送信するために必要
+                });
+                const data: unknown = await response.json();
+                const parsed = csrfResponseSchema.safeParse(data);
+                if (parsed.success) {
+                    setCsrfToken(parsed.data.csrfToken);
+                } else {
+                    console.error('Unexpected CSRF response format:', data);
+                }
+            } catch (error) {
+                console.error('CSRF token fetch error:', error);
+            }
+        };
+
+        fetchCsrfToken();
+
+        // セッションストレージからデータを取得して復元
+        const data = getDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM);
+        if (data) {
+            reset(data);
+        }
+    }, [reset]);
+
+    /**
+     * 入力値とトークンを sessionStorage に保存し、確認画面へ遷移する。
+     *
+     * @param data - バリデーション済みのフォームデータ
+     */
+    const onSubmit = async (data: contactFormData) => {
+        try {
+            if (!csrfToken) {
+                throw new Error('CSRF token is missing.');
+            }
+
+            setDataBySessionStorage(STORAGE_KEYS.CONTACT_FORM, data);
+            setDataBySessionStorage(STORAGE_KEYS.CSRF_TOKEN, csrfToken);
+
+            router.push('/contact/confirm');
+        } catch (error) {
+            setFormError(error, setError);
+        }
+    };
+
+    return { register, handleSubmit, errors, onSubmit };
+};

--- a/front/src/app/hooks/useIsHomePath.ts
+++ b/front/src/app/hooks/useIsHomePath.ts
@@ -3,8 +3,9 @@
 import { usePathname } from 'next/navigation';
 
 /**
- * ホームパスかどうかを判断する
- * @returns true: ホームパス, false: ホームパス以外
+ * 現在のパスがホーム（`/`）以外かどうかを判断する。
+ *
+ * @returns ホーム以外なら true（Footer 等の表示制御に使う）
  */
 export const useIsHomePath = () => {
     const pathname = usePathname();

--- a/front/src/app/hooks/usePersonalDevData.ts
+++ b/front/src/app/hooks/usePersonalDevData.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import type { PersonalDevDataType } from '@/app/types/personal-data-types';
+
+/** `/api/gcs/personaldev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const personalDevResponseSchema = z.object({
+    personaldev: z.array(
+        z.object({
+            title: z.string(),
+            description: z.string(),
+            tech: z.array(z.string()),
+            url: z.string(),
+        }),
+    ),
+});
+
+/**
+ * 個人開発データを GCS API から取得するフック。
+ *
+ * @returns 取得したデータ一覧（`personalDevDataList`）と読み込み状態（`isLoading`）
+ */
+export const usePersonalDevData = () => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [personalDevDataList, setPersonalDevDataList] = useState<PersonalDevDataType[]>([]);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setIsLoading(true);
+            try {
+                const result = await fetch('/api/gcs/personaldev');
+                if (result.ok) {
+                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
+                    const data: unknown = await result.json();
+                    const parsed = personalDevResponseSchema.safeParse(data);
+                    if (parsed.success) {
+                        setPersonalDevDataList(parsed.data.personaldev);
+                    } else {
+                        console.error('Unexpected API response format:', data);
+                    }
+                }
+            } catch (error) {
+                console.error('Error fetching personal development data:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    return { personalDevDataList, isLoading };
+};

--- a/front/src/app/hooks/useSampleDevData.ts
+++ b/front/src/app/hooks/useSampleDevData.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import type { SampleDevDataType } from '@/app/types/sample-data-types';
+
+/** `/api/gcs/sampledev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
+const sampleDevResponseSchema = z.object({
+    sampledev: z.array(
+        z.object({
+            title: z.string(),
+            description: z.string(),
+            tech: z.array(z.string()),
+            imageUrl: z.string(),
+            url: z.string(),
+        }),
+    ),
+});
+
+/**
+ * サンプル開発データを GCS API から取得するフック。
+ *
+ * @returns 取得したデータ一覧（`sampleDevDataList`）と読み込み状態（`isLoading`）
+ */
+export const useSampleDevData = () => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [sampleDevDataList, setSampleDevDataList] = useState<SampleDevDataType[]>([]);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setIsLoading(true);
+            try {
+                const result = await fetch('/api/gcs/sampledev');
+                if (result.ok) {
+                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
+                    const data: unknown = await result.json();
+                    const parsed = sampleDevResponseSchema.safeParse(data);
+                    if (parsed.success) {
+                        setSampleDevDataList(parsed.data.sampledev);
+                    } else {
+                        console.error('Unexpected API response format:', data);
+                    }
+                }
+            } catch (error) {
+                console.error('Error fetching sample development data:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    return { sampleDevDataList, isLoading };
+};

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence } from 'framer-motion';
 // utils
-import { useIsHomePath } from '@/app/utils/path/path-functions';
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import Hero from '@/app/components/hero/Hero';

--- a/front/src/app/personaldev/page.tsx
+++ b/front/src/app/personaldev/page.tsx
@@ -1,27 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { PulseLoader } from 'react-spinners';
-import { z } from 'zod';
 // types
 import type { PersonalDevDataType } from '@/app/types/personal-data-types';
-// utils
-import { useIsHomePath } from '@/app/utils/path/path-functions';
-
-/** `/api/gcs/personaldev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
-const personalDevResponseSchema = z.object({
-    personaldev: z.array(
-        z.object({
-            title: z.string(),
-            description: z.string(),
-            tech: z.array(z.string()),
-            url: z.string(),
-        }),
-    ),
-});
+// hooks
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
+import { usePersonalDevData } from '@/app/hooks/usePersonalDevData';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import Footer from '@/app/components/layout/Footer';
@@ -32,34 +19,7 @@ import PageTransition from '@/app/components/page-transition/PageTransition';
  */
 const PersonalHistoryDevPage = () => {
     const isHome: boolean = useIsHomePath();
-    const [isLoading, setIsLoading] = useState(true);
-    const [personalDevDataList, setPersonalDevDataList] = useState<PersonalDevDataType[]>([]);
-
-    useEffect(() => {
-        const fetchData = async () => {
-            setIsLoading(true);
-            try {
-                const result = await fetch('/api/gcs/personaldev');
-
-                if (result.ok) {
-                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
-                    const data: unknown = await result.json();
-                    const parsed = personalDevResponseSchema.safeParse(data);
-                    if (parsed.success) {
-                        setPersonalDevDataList(parsed.data.personaldev);
-                    } else {
-                        console.error('Unexpected API response format:', data);
-                    }
-                }
-            } catch (error) {
-                console.error('Error fetching personal development data:', error);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-
-        fetchData();
-    }, []);
+    const { personalDevDataList, isLoading } = usePersonalDevData();
 
     const containerVariants = {
         hidden: { opacity: 0 },

--- a/front/src/app/sampledev/page.tsx
+++ b/front/src/app/sampledev/page.tsx
@@ -1,29 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { PulseLoader } from 'react-spinners';
 import Image from 'next/image';
-import { z } from 'zod';
 // types
 import type { SampleDevDataType } from '@/app/types/sample-data-types';
-// utils
-import { useIsHomePath } from '@/app/utils/path/path-functions';
-
-/** `/api/gcs/sampledev` の応答形状。外部入力のため unknown で受けてこのスキーマで検証する。 */
-const sampleDevResponseSchema = z.object({
-    sampledev: z.array(
-        z.object({
-            title: z.string(),
-            description: z.string(),
-            tech: z.array(z.string()),
-            imageUrl: z.string(),
-            url: z.string(),
-        }),
-    ),
-});
+// hooks
+import { useIsHomePath } from '@/app/hooks/useIsHomePath';
+import { useSampleDevData } from '@/app/hooks/useSampleDevData';
 // components
 import Navbar from '@/app/components/nav-bar/Navbar';
 import PageTransition from '@/app/components/page-transition/PageTransition';
@@ -34,34 +20,7 @@ import Footer from '@/app/components/layout/Footer';
  */
 const SampleHistoryDevPage = () => {
     const isHome: boolean = useIsHomePath();
-    const [isLoading, setIsLoading] = useState(true);
-    const [sampleDevDataList, setSampleDevDataList] = useState<SampleDevDataType[]>([]);
-
-    useEffect(() => {
-        const fetchData = async () => {
-            setIsLoading(true);
-            try {
-                const result = await fetch('/api/gcs/sampledev');
-
-                if (result.ok) {
-                    // 外部入力は unknown で受け、スキーマ検証でナローイングしてから使う。
-                    const data: unknown = await result.json();
-                    const parsed = sampleDevResponseSchema.safeParse(data);
-                    if (parsed.success) {
-                        setSampleDevDataList(parsed.data.sampledev);
-                    } else {
-                        console.error('Unexpected API response format:', data);
-                    }
-                }
-            } catch (error) {
-                console.error('Error fetching sample development data:', error);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-
-        fetchData();
-    }, []);
+    const { sampleDevDataList, isLoading } = useSampleDevData();
 
     const containerVariants = {
         hidden: { opacity: 0 },


### PR DESCRIPTION
## 概要

親 issue #84 の #83。frontend.md「クライアントロジックはカスタムフックに切り出す」に対し、ページに直書きされていた fetch・CSRF・送信・sessionStorage 操作をフックへ抽出し、ページを UI 描画に専念させる。挙動は不変。

Closes #83

## 変更点
- **データ取得フック**: `usePersonalDevData` / `useSampleDevData` を新設し、personaldev/sampledev ページから抽出。
- **お問い合わせフック**: `useContactForm`（CSRF 取得・入力復元・確認画面遷移）/ `useContactConfirm`（復元・メール送信・戻る）を新設し、contact/form・contact/confirm から抽出。
- **配置整理**: `useIsHomePath` を `utils/path/path-functions.ts` → `hooks/useIsHomePath.ts` へ移動（`useModal` と同じ hooks/ に統一）。参照 7 箇所の import を更新。
- **frontend.md**: 小規模のため現行の「機能種類別フラット構成」を許容パターンとして注記（㉑ コンポーネント設計の一貫性）。

## 挙動不変の担保
- ロジックはそのまま hooks へ移設（値・分岐・遷移先すべて同一）。
- **page/scenario E2E をローカルで実行 → 30/30 passed**（contact フロー・データページ・ナビゲーション全て従来どおり）。
- `tsc --noEmit` / `pnpm format:check` / `pnpm lint` / `pnpm test`(20/20): 通過。

## ドキュメント影響
frontend.md にコンポーネント構成の注記を追加（`.claude/rules/` の内容編集で、ルール追加/削除ではないため CLAUDE.md テーブルは変更不要）。機能・API・データ変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)