### PR TITLE
chore(rules): my-custom-skills PR #125/#126-127 のルールを取り込む

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,6 +1,6 @@
 ---
 description: Next.js (App Router) フロントエンド設計・コンポーネント規約
-globs: "front/src/app/**,front/src/components/**,front/src/lib/**"
+globs: "front/src/app/**,front/src/components/**,front/src/hooks/**,front/src/contexts/**,front/src/repositories/**,front/src/schemas/**,front/src/constants/**,front/src/types/**,front/src/lib/**"
 ---
 
 # フロントエンドルール（Next.js App Router）
@@ -28,7 +28,39 @@ globs: "front/src/app/**,front/src/components/**,front/src/lib/**"
 ## ロジック分離
 
 - **クライアントコンポーネント**のロジックは**カスタムフック**（`hooks/`）に切り出す。コンポーネントは UI 描画に専念する。
-- **サーバーコンポーネント**のデータ取得は `page.tsx` や `lib/` 内のサーバー関数で行う（hooks は使用しない）。
+- **サーバーコンポーネント**のデータ取得は `page.tsx` から `repositories/` の関数を呼んで行う（hooks は使用しない）。
+
+## 関心別にディレクトリを切る
+
+`types/` `constants/` `schemas/` `repositories/` は**それぞれ独立したディレクトリ**として `src/` 直下に置く。いずれも**単一ファイルにまとめない**（`src/types.ts` / `lib/validation.ts` のような形は禁止。ドメイン単位でファイルを分ける）。詳細は `typescript.md`「型定義の配置」「定数の配置」「スキーマの配置」に従う。
+
+| ディレクトリ | 置くもの | 置かないもの |
+|---|---|---|
+| `types/` | 2 箇所以上から参照される型 | 値・ロジック |
+| `constants/` | 全環境で不変な値 | 環境変数・型を導出する定数（`types/` 側へ） |
+| `schemas/` | Zod スキーマ（フォーム・API レスポンスの検証） | 検証を伴わない型定義（`types/` へ） |
+| `repositories/` | **API アクセス**（`fetch` / API クライアント呼び出し） | UI・画面都合の整形・業務判断 |
+| `lib/` | **通信を持たない純粋ユーティリティ**（日付整形・計算等） | API アクセス（`repositories/` へ）・定数・型 |
+
+- **`fetch` を書いてよいのは `repositories/` だけ**。コンポーネント・hooks・`lib/` から直接叩かない。呼び出し口を 1 箇所に閉じることで、認証ヘッダ・エラー処理・リトライの実装が散らばらない。
+- ディレクトリ名は**複数形で統一**する（`types` / `constants` / `schemas` / `repositories`）。
+
+### 目標ディレクトリ構成
+
+```
+front/src/
+├── app/                    # ルーティング（App Router）・API ルート（Hono）
+├── components/             # UI（ui/ は shadcn プリミティブ）
+├── hooks/                  # クライアントロジック（useXxx）
+├── contexts/               # Context 定義（関心事ごとに分割）
+├── repositories/           # API アクセス（fetch はここだけ・ドメイン単位で分割）
+├── schemas/                # Zod スキーマ（フォーム・API レスポンス検証）
+├── lib/                    # 純粋ユーティリティ（通信しない）
+├── constants/              # 共通定数（環境変数は置かない）
+└── types/                  # 型定義
+```
+
+> 現状: 実装は `front/src/app/` 配下に `types/` `schema/` `constants/` `hooks/` `contexts/` `utils/` を置き、`fetch` は hooks・contexts に散在している。**新規追加・リファクタ時は上記構成を目標とする**（移行は別 issue で扱う）。
 
 ## インポート
 

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -52,6 +52,25 @@ type OnSelect = (id: string) => void;
 
 **補足**: NestJS の DTO は `class-validator` デコレータを付けるため **class** で定義する（type/interface ではない）。本節は「型定義」に対する指針であり、バリデーション用 DTO クラスは対象外。
 
+## スキーマバリデーションは Zod に統一する
+
+**TypeScript のスキーマバリデーションは Zod を使う。** フロントエンド（フォーム）と API ルート（Hono）で**同じ 1 つのライブラリに揃える**（`yup` / `joi` / 自前の検証関数を混在させない）。
+
+- **理由**: 層ごとに検証ライブラリが変わると、同じ入力ルールを別の書き方で二重に定義することになる。Zod なら**スキーマそのものを共有でき**、片方から他方を導出できる。
+- **型はスキーマから導出する**。`z.infer<typeof schema>` を使い、**同じ形を手書きで二重定義しない**。**スキーマが単一の真実**であり、型はその影である。
+- 外部入力（API レスポンス・`JSON.parse`・フォーム入力）は `unknown` で受け、**Zod で `parse` してからドメインに入れる**。
+- クライアント（`contactSchema`）と API ルートの検証は、信頼境界が違うため**両方に必要**だが、**定義は 1 つ**にして双方から参照する。
+- 用途別のアダプタを使う（`react-hook-form` の `zodResolver` / `@hono/zod-validator`）。**アダプタは変わってもスキーマは変わらない**。
+
+### スキーマの配置（`schemas/` 集約）
+
+- スキーマは**ソースルート直下の `schemas/` ディレクトリ**に集約する（本プロジェクトでは `front/src/schemas/`）。
+- **`lib/validation.ts` のような単一ファイルにまとめない。** ディレクトリを切り、ドメイン単位でファイルを分ける（`schemas/contact.ts` 等）。`lib/` `utils/` の下に置かない（「関数の置き場」と分離する）。
+- 命名は**ディレクトリが複数形の `schemas`**。`schema/` のような単数形にしない。
+- **スキーマから導出した型は `types/` に再定義しない。** `z.infer<typeof contactSchema>` を `schemas/contact.ts` から `export` し、それを参照する。
+- **検証を伴わない純粋な型は `schemas/` に置かない**（`types/` へ）。`schemas/` に置くのは「実行時に `parse` するもの」だけ。
+- barrel（`schemas/index.ts`）は作らない（理由は型・定数と同じ）。
+
 ## 型定義の配置（コロケーション / `types/` 集約）
 
 型を各ファイルに散在させず、**参照範囲**で置き場所を決める。判断軸は「**その型を参照するファイルが 1 つに閉じるか**」。
@@ -60,6 +79,27 @@ type OnSelect = (id: string) => void;
 |---|---|
 | **1 ファイルに閉じる** | その定義ファイル内にコロケーション（`export` しない） |
 | **2 ファイル以上** / レイヤ・機能をまたぐ | `types/` に集約して `export` |
+
+### 置き場所（ディレクトリを切る）
+
+- 集約先は**ソースルート直下の `types/` ディレクトリ**とする。本プロジェクト（Next.js `src/` 構成）では **`front/src/types/`**。
+- **単一ファイルにまとめない。** `lib/type.ts` / `src/type.ts` のように 1 ファイルへ全型を詰め込む形は禁止。必ず**ディレクトリを切り、ドメイン単位でファイルを分ける**。
+- **`lib/` `utils/` の下に型ファイルを置かない。** `lib/` は「関数の置き場」、`types/` は「型の置き場」で分離する（定数も同様。「定数の配置」参照）。
+- 命名は**ディレクトリが複数形の `types`、ファイルはドメイン名の単数形**（`types/contact.ts` 等）。`type.ts` / `Types.ts` のような単数形・PascalCase のディレクトリ名は使わない。
+
+```
+front/src/
+├── repositories/   # API アクセス（通信はここだけ）
+├── schemas/        # Zod スキーマ
+├── lib/            # 純粋ユーティリティ（通信しない）
+├── constants/      # 値
+└── types/          # 型
+    └── contact.ts
+```
+
+❌ `src/lib/type.ts` に全型を詰め込む / ✅ `src/types/contact.ts` にドメイン単位で分ける
+
+> 現状: 本プロジェクトは `front/src/app/types/` `front/src/app/schema/` `front/src/app/constants/` `front/src/app/utils/` 配置で、上記の目標構成と乖離がある。**新規追加・リファクタ時は上記を目標とする**。
 
 ### 運用ルール
 
@@ -98,6 +138,16 @@ export type Task = { id: string; title: string; status: TaskStatus };
 |---|---|
 | **1 ファイルに閉じる** | その定義ファイルの先頭で `const` 宣言（`export` しない） |
 | **2 ファイル以上** / レイヤ・機能をまたぐ | `constants/` に集約して `export` |
+
+### 置き場所（ディレクトリを切る）
+
+型と同じ方針で置き場所を決める（詳細は「型定義の配置」の同名節）。
+
+- 集約先は**ソースルート直下の `constants/` ディレクトリ**（本プロジェクトでは `front/src/constants/`）。
+- **単一ファイルにまとめない。** `lib/constants.ts` / `src/constants.ts` のように 1 ファイルへ全定数を詰め込む形は禁止。**ディレクトリを切り、ドメイン単位でファイルを分ける**。
+- 命名は**ディレクトリが複数形の `constants`**（`constant.ts` のような単数形の単一ファイルにしない）。
+
+❌ `src/lib/constants.ts` に全定数を詰め込む / ✅ `src/constants/contact.ts` にドメイン単位で分ける
 
 ### 運用ルール
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ Next.js + Hono によるポータルWebアプリケーション（フロント�
 | github-issue.md | 全体 | GitHub issue 運用（ブランチと対で起票・open/close で進捗管理・PR で自動クローズ） |
 | testing.md | 全体 | テスト分類・原則・テストツール（Jest / Playwright） |
 | coding-standards.md | 全体 | コーディング規約（TypeScript strict・pnpm・ESLint/Prettier） |
-| typescript.md | `front/src/**` | TypeScript 固有規約（type/interface 使い分け・型/定数の配置・any 禁止・enum 回避・import type） |
+| typescript.md | `front/src/**` | TypeScript 固有規約（type/interface 使い分け・Zod 統一・型/定数/スキーマの配置・any 禁止・enum 回避・import type） |
 | error-handling.md | 全体 | エラーハンドリング方針（バリデーション・例外・ログ） |
 | security.md | 全体 | セキュリティ設計方針（認証・CORS・インジェクション対策・シークレット管理） |
 | jsdoc.md | `front/src/**` | JSDoc（TSDoc）規約（公開シンボルに必須） |
-| frontend.md | `front/src/app/**`, `front/src/components/**`, `front/src/lib/**` | Next.js フロントエンド設計・コンポーネント規約 |
+| frontend.md | `front/src/app/**`, `front/src/components/**`, `front/src/hooks/**`, `front/src/repositories/**`, `front/src/schemas/**`, `front/src/lib/**` 等 | Next.js フロントエンド設計・コンポーネント規約・関心別ディレクトリ |
 | api.md | `front/src/app/api/**` | Hono API 設計・ルート構成（Next.js 一体型） |


### PR DESCRIPTION
## 概要

`my-custom-skills` の PR #123 以降を調査し、本プロジェクトの `.claude/rules/` に未反映かつ該当するものを取り込む。

Closes #92

## 調査結果

前提として `~/.claude/skills/rules-update` は `my-custom-skills@main` と一致しており（drift なし）、未反映だったのは本プロジェクトの `.claude/rules/` のみ。「既に入っていた」ものは 0 件。

| PR | 内容 | 判定 |
|---|---|---|
| #123 | DB 監査列の自動化 | スキップ（DB を持たない。GCS + Resend のみ） |
| #124 #129 #131 #133 | Vercel デプロイ制御（`vercel.json` / `ignoreCommand`） | スキップ（デプロイ先は Cloud Run） |
| #125 | 型・定数のディレクトリを切る | **取り込み** |
| #126 #127 | `repositories/` 分離・`schemas/`・Zod 統一 | **取り込み**（Hono の CQRS-lite は除外） |

## 変更内容

- **`.claude/rules/typescript.md`**
  - 「スキーマバリデーションは Zod に統一する」＋「スキーマの配置（`schemas/` 集約）」を追加
  - 型・定数それぞれに「置き場所（ディレクトリを切る）」節を追加
- **`.claude/rules/frontend.md`**
  - 「関心別にディレクトリを切る」表（`types` / `constants` / `schemas` / `repositories` / `lib`）を追加
  - `fetch` を書いてよいのは `repositories/` だけ、を明記
  - 目標ディレクトリ構成を追加、frontmatter の globs を拡張
- **`CLAUDE.md`**: Rules テーブルの scope・内容を同期

## Hono の CQRS-lite を除外した理由

PR #126 は `api/hono.md` に `usecases/` `queries/` `repositories/` の層分割を追加しているが、これは**独立した Hono バックエンド**を前提としたもの。本プロジェクトの Hono は Next.js の catch-all route 上に載る薄い BFF（GCS 取得とメール送信のみ・DB なし）であり、適用すると空の層を量産するだけになるため `api.md` は変更していない。

## 既存コードとの乖離について

新ルールは `front/src/{types,schemas,repositories,constants}` を要求するが、実装は `front/src/app/{types,schema,constants,utils}` 配置で、`fetch` も hooks・contexts に散在している。
ルールを無条件の断定にせず `> 現状:` の注記を添え、**目標状態であり移行は別 issue** と明示した（注記がないと `/self-review` が既存コード全体を違反として指摘し続けるため）。

コード側の移行は以下で対応する:
- #93（親） / #94 ディレクトリ移行 / #95 `fetch` の `repositories/` 集約

## ドキュメント更新

`documentation.md` の影響マップに従い `CLAUDE.md`（Rules テーブル）を更新済み。`docs/` 配下はルール文書の変更のみで仕様変更を伴わないため更新不要。

## テスト

Markdown（`.claude/rules/` / `CLAUDE.md`）のみの変更でコード差分がないため、`front/` の format/lint/test は対象外・未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)